### PR TITLE
KIWI-1323: Github migration - Post cleanup for Bav CRIi Frontend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipv-cri-bav-front repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @alphagov/di-ipv-kiwi-front-codeowners
+* @govuk-one-login/kiwi-front-codeowners
 
 # The following allows QA to review changes to /tests directory
 
-tests/ @alphagov/di-ipv-kiwi-qa-codeowners @alphagov/di-ipv-kiwi-front-codeowners
+tests/ @govuk-one-login/kiwi-qa-codeowners @govuk-one-login/kiwi-front-codeowners


### PR DESCRIPTION
- Add the CODEOWNERS for new govuk-one-login github BAV Front

- [KIWI-1323](https://govukverify.atlassian.net/browse/KIWI-1323)


[KIWI-1323]: https://govukverify.atlassian.net/browse/KIWI-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ