### PR TITLE
[KIWI-1233] - BAV | FE | Build Account Details Screen

### DIFF
--- a/src/app/bav/controllers/accountDetails.js
+++ b/src/app/bav/controllers/accountDetails.js
@@ -1,0 +1,5 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+
+class AccountDetailsController extends BaseController {}
+
+module.exports = AccountDetailsController; 

--- a/src/app/bav/controllers/accountDetails.test.js
+++ b/src/app/bav/controllers/accountDetails.test.js
@@ -1,0 +1,11 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const AccountDetailsController = require('./accountDetails');
+
+describe("AccountDetailsController", () => {
+  const accountDetailsController = new AccountDetailsController({ route: '/test' });
+
+  it("should be an instance of BaseController", () => {
+    expect(accountDetailsController).toBeInstanceOf(BaseController);
+  });
+
+})

--- a/src/app/bav/fields.js
+++ b/src/app/bav/fields.js
@@ -1,16 +1,20 @@
-//WIP: placeholder values for BAV input fields 
-
 module.exports = {
-  surname: {
-    type: "text",
-    journeyKey: "surname",
+  sortCode: {
+    type: "number",
+    journeyKey: "sortCode",
+    validate: [
+      "required",
+      // Subject to change, potential to allow dashes ("-") etc
+      { type: "exactlength", arguments: [6] },
+    ]
   },
-  firstName: {
-    type: "text",
-    journeyKey: "firstName",
-  },
-  middleName: {
-    type: "text",
-    journeyKey: "middleName",
+  accountNumber: {
+    type: "number",
+    journeyKey: "accountNumber",
+    validate: [
+      "required",
+      { type: "minlength", arguments: [6] },
+      { type: "maxlength", arguments: [8] },
+    ] 
   }
 };

--- a/src/app/bav/fields.js
+++ b/src/app/bav/fields.js
@@ -1,11 +1,10 @@
 module.exports = {
   sortCode: {
-    type: "number",
+    type: "text",
     journeyKey: "sortCode",
     validate: [
       "required",
-      // Subject to change, potential to allow dashes ("-") etc
-      { type: "exactlength", arguments: [6] },
+      {type: "regexNumber", fn: (value) => value.match(/^\d{6}$|^\d{2}-\d{2}-\d{2}$|^\d{2} \d{2} \d{2}$/)}
     ]
   },
   accountNumber: {

--- a/src/app/bav/steps.js
+++ b/src/app/bav/steps.js
@@ -1,5 +1,6 @@
-const landingPage = require("./controllers/landingPage");
 const root = require("./controllers/root");
+const landingPage = require("./controllers/landingPage");
+const accountDetails = require("./controllers/accountDetails");
 const { APP } = require("../../lib/config");
 
 module.exports = {
@@ -14,5 +15,10 @@ module.exports = {
   [`${APP.PATHS.LANDING_PAGE}`]: {
     controller: landingPage,
     next: APP.PATHS.ACCOUNT_DETAILS
-  }
+  },
+  [`${APP.PATHS.ACCOUNT_DETAILS}`]: {
+    fields: ["sortCode", "accountNumber"],
+    controller: accountDetails,
+    next: APP.PATHS.CONFIRM_DETAILS,
+  },
 };

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -14,7 +14,8 @@ module.exports = {
     PATHS: {
       BAV: "/",
       LANDING_PAGE: "/prove-identity-bank-account",
-      ACCOUNT_DETAILS: "/account-details",
+      ACCOUNT_DETAILS: "/enter-account-details",
+      CONFIRM_DETAILS: "/confirm-details",
       ABORT: "/abort",
     },
     ANALYTICS: {

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -2,13 +2,13 @@ sortCode:
   label: Sort code
   hint: A sort code is 6 digits long. It's usually formatted as three pairs of numbers. For example, 12-34-56
   validation:
-    default: "Enter your sort code as it appears on your bank account"
-    exactlength: "Enter your sort code as it appears on your bank account"
+    default: "Enter a sort code"
+    regexNumber: "Enter a valid sort code like 12-34-56"
 
 accountNumber:
   label: Account number
   hint: An account number is between 6 and 8 digits long. For example, 31926819
   validation:
-    default: "Enter your account number as it appears on your bank account"
-    minlength: "Your account number must be between 6 and 8 digits long"
-    maxlength: "Your account number must be between 6 and 8 digits long"
+    default: "Enter an account number"
+    minlength: "Account number must be between 6 and 8 digits"
+    maxlength: "Account number must be between 6 and 8 digits"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -1,29 +1,14 @@
-#WIP: placeholder values for BAV input fields 
-
-surname:
-  label: Last name
-  hint:
+sortCode:
+  label: Sort code
+  hint: A sort code is 6 digits long. It's usually formatted as three pairs of numbers. For example, 12-34-56
   validation:
-    default: "Enter your last name as it appears on your photo ID"
-    maxlength: "Enter your last name as it appears on your photo ID"
-    regexNumber: "Your last name cannot include numbers"
-    regexSpecialCharacters: "Enter your last name as it appears on your photo ID"
+    default: "Enter your sort code as it appears on your bank account"
+    exactlength: "Enter your sort code as it appears on your bank account"
 
-
-firstName:
-  label: First name
-  hint:
+accountNumber:
+  label: Account number
+  hint: An account number is between 6 and 8 digits long. For example, 31926819
   validation:
-    default: "Enter your first name as it appears on your photo ID"
-    maxlength: "Enter your first name as it appears on your photo ID"
-    regexNumber: "Your first name cannot include numbers"
-    regexSpecialCharacters: "Enter your first name as it appears on your photo ID"
-
-middleName:
-  label: Middle name(s)
-  hint: Leave this blank if you do not have any middle names
-  validation:
-    default: "Enter your middle name as it appears on your photo ID"
-    maxlength: "Enter your middle name as it appears on your photo ID"
-    regexNumber: "Your middle name cannot include numbers"
-    regexSpecialCharacters: "Enter your middle name as it appears on your photo ID"
+    default: "Enter your account number as it appears on your bank account"
+    minlength: "Your account number must be between 6 and 8 digits long"
+    maxlength: "Your account number must be between 6 and 8 digits long"

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -27,3 +27,6 @@ landingPage:
     abortText1: "Go to the service you want to use and "
     abortLink: "/abort"
     abortText2: "find other ways to prove your identity"
+
+accountDetails:
+  title: "Enter your account details"

--- a/src/views/bav/enter-account-details.html
+++ b/src/views/bav/enter-account-details.html
@@ -1,0 +1,55 @@
+{% extends "base-form.njk" %}
+{# the content for this page is controlled by locales/en/default.yml #}
+{% set hmpoPageKey = "enterAccountDetails" %}
+{% set gtmJourney = "bav - enterAccountDetails" %}
+
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "hmpo-text/macro.njk" import hmpoText %}
+{% from "hmpo-form/macro.njk" import hmpoForm %}
+
+
+{% block mainContent %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <h1 id="header" class="gov" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+        {{ translate("accountDetails.title") }}
+    </h1>
+  </div>
+</div>
+    
+    {% call hmpoForm(ctx, {attributes: {onsubmit: 'window.disableFormSubmit()'} }) %}
+
+    {{ hmpoText(ctx, {
+        id: "sortCode",
+        classes: "govuk-input--width-5 govuk-input--extra-letter-spacing"
+    })}}
+
+    {{ hmpoText(ctx, {
+      id: "accountNumber",
+      classes: "govuk-input--width-10 govuk-input--extra-letter-spacing"
+  })}}
+
+
+    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+
+    {% endcall %}
+
+{% endblock %}
+
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+{% endblock %}
+
+
+{% block bodyEnd %}
+  {% block scripts %}
+    <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
+    <script type="text/javascript" src="/public/javascripts/all.js"></script>
+    <script type="text/javascript" src="/public/javascripts/application.js"></script>
+    <script type="text/javascript" nonce='{{cspNonce}}'>window.DI.appInit({uaContainerId: '{{uaContainerId}}', analyticsCookieDomain: '{{analyticsCookieDomain}}', isGa4Enabled: '{{isGa4Enabled}}', ga4ContainerId: '{{ga4ContainerId}}'})</script>
+  {% endblock %}
+{% endblock %}

--- a/src/views/bav/enter-account-details.html
+++ b/src/views/bav/enter-account-details.html
@@ -47,9 +47,7 @@
 
 {% block bodyEnd %}
   {% block scripts %}
-    <script type="text/javascript" src="/public/javascripts/analytics.js"></script>
     <script type="text/javascript" src="/public/javascripts/all.js"></script>
     <script type="text/javascript" src="/public/javascripts/application.js"></script>
-    <script type="text/javascript" nonce='{{cspNonce}}'>window.DI.appInit({uaContainerId: '{{uaContainerId}}', analyticsCookieDomain: '{{analyticsCookieDomain}}', isGa4Enabled: '{{isGa4Enabled}}', ga4ContainerId: '{{ga4ContainerId}}'})</script>
   {% endblock %}
 {% endblock %}


### PR DESCRIPTION
### What changed

Add bank account details entry screen to BAV FE
Errors are triggered if either input is empty, or the number of characters does not adhere to the length rules for each input (6 for sort code and 6-8 for account number). Additionally, "dd-dd-dd" and "dd dd dd" are allowed for sort code.

### Issue tracking

- [KIWI-1233](https://govukverify.atlassian.net/browse/KIWI-1333)

### Evidence
![image](https://github.com/govuk-one-login/ipv-cri-bav-front/assets/118540036/c3a7c874-b23f-4978-a466-92e0245e92ec)
![image](https://github.com/govuk-one-login/ipv-cri-bav-front/assets/118540036/70409319-71a5-48f9-90fc-4f39996678d9)
![image](https://github.com/govuk-one-login/ipv-cri-bav-front/assets/118540036/d9700582-c4e4-4b5c-b6a5-f614799af092)




[KIWI-1233]: https://govukverify.atlassian.net/browse/KIWI-1233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ