### PR TITLE
KIWI-BAV-1333-TD Scenario data reporting update

### DIFF
--- a/test/browser/features/HappyPath/BAVAccountDetailsPage.feature
+++ b/test/browser/features/HappyPath/BAVAccountDetailsPage.feature
@@ -8,7 +8,7 @@ Feature: Enter Bank Account Details
     Then the user is directed to the Account Details screen
 
  
-  Scenario Outline: User routed to Check Your Answers Screen
+  Scenario Outline: User routed to Check Your Answers Screen: <sortCode> and <accountNumber>
     Given the user has entered a Sort Code of <sortCode>
     Given the user has entered an Account Number of <accountNumber>
     When the user clicks the Continue button
@@ -21,11 +21,9 @@ Feature: Enter Bank Account Details
       | "123456"   | "31926819"    |
 
  Scenario: Back button routes user to Landing Page
-    Given the user is on the Account Details Screen
     When the user clicks on the “Back” link
     Then they are routed to the BAV Landing Page
 
   Scenario: Browser back button routes user to Landing Page
-    Given the user is on the Account Details Screen
     When the user clicks on the Back button on their browser
     Then they are routed to the BAV Landing Page

--- a/test/browser/features/UnHappyPath/BAVUnhappyAccountDetails.feature
+++ b/test/browser/features/UnHappyPath/BAVUnhappyAccountDetails.feature
@@ -11,7 +11,7 @@ Feature: Enter Incorrect Bank Account Details
       When the user clicks the Continue button
       Then an error message is shown to the user
 
-   Scenario Outline:  On-screen error when Account Number in wrong format
+   Scenario Outline:  On-screen error when Account Number in wrong format: <accountNumber>
       Given the user has entered a Sort Code of "123456"
       Given the user has entered an Account Number of <accountNumber>
       When the user clicks the Continue button
@@ -22,7 +22,7 @@ Feature: Enter Incorrect Bank Account Details
          | "319268190"   |
          | "31926"       |
 
-   Scenario Outline: On-screen error when Sort Code in wrong format
+   Scenario Outline: On-screen error when Sort Code in the wrong format: <sortCode>
       Given the user has entered a Sort Code of <sortCode>
       Given the user has entered an Account Number of "31926819"
       When the user clicks the Continue button


### PR DESCRIPTION
## Proposed changes
Pass in data values used in parametised scenario outline

### What changed
Amended the Scenario Outline header to include the parametised value of the sortCode and accountNumber variables

### Why did it change
Adding the variables to the description will make identifying any failures easier as the value used is now in the header

### Issue tracking
KIWI-BAV-1333 (https://govukverify.atlassian.net/browse/KIWI-BAV-1333)

## Checklists

### Environment variables or secrets
- [ x ] Added screenshots to show the implementation is working
<img width="849" alt="Screenshot 2023-12-01 at 10 15 48" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/115989182/6c47c9fd-3b22-43ee-b7f0-dd694373e7b5">
<img width="779" alt="Screenshot 2023-12-01 at 10 16 40" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/115989182/9bd59e83-da68-4cd5-8207-043ccaf77318">


### Other considerations
NA
