### PR TITLE
Fix failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "test:browser:report": "node ./test/utils/multiReportGenerator.js",
     "test:browser": "wait-on tcp:127.0.0.1:8090 tcp:127.0.0.1:5040 && API_BASE_URL=http://127.0.0.1:8090 cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json",
     "test:browser:ci": "npm-run-all -p -r start:ci mocks test:browser && npm run test:browser:report",
-    "test": "node_modules/.bin/jest --testPathPattern=app/bav --coverage",
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'"
   },
   "repository": {

--- a/test/browser/pages/accountDetailsEditPage.js
+++ b/test/browser/pages/accountDetailsEditPage.js
@@ -26,7 +26,7 @@ module.exports = class PlaywrightDevPage {
 
   async checkErrorText() {
     const errorText = await this.page
-      .locator("#error-summary-title")
+      .locator("h2.govuk-error-summary__title")
       .textContent();
     return errorText.trim();
   }

--- a/test/browser/pages/accountDetailsPage.js
+++ b/test/browser/pages/accountDetailsPage.js
@@ -26,7 +26,7 @@ module.exports = class PlaywrightDevPage {
 
   async checkErrorText() {
     const errorText = await this.page
-      .locator("#error-summary-title")
+      .locator("h2.govuk-error-summary__title")
       .textContent();
     return errorText.trim();
   }

--- a/test/browser/pages/landingPage.js
+++ b/test/browser/pages/landingPage.js
@@ -36,7 +36,7 @@ module.exports = class PlaywrightDevPage {
 
   async checkErrorText() {
     const errorText = await this.page
-      .locator("#error-summary-title")
+      .locator("h2.govuk-error-summary__title")
       .textContent();
     return errorText.trim();
   }


### PR DESCRIPTION
## Proposed changes

### What changed

Changed the selector used for the error summary box as the ID was removed in [version 4.4 of govuk-components](https://github.com/alphagov/govuk-frontend/compare/v4.3.1...v4.4.1) so it can no longer be used

### Why did it change

So that tests are able to find the right element

<img width="337" alt="Screenshot 2023-12-14 at 11 44 28" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/40401118/d6272ef3-dde8-4bf1-97d7-e0de31c59786">

