### PR TITLE
KIWI-1530: Don't run sonar check for dependabot

### DIFF
--- a/.github/workflows/pull-request-sonar.yml
+++ b/.github/workflows/pull-request-sonar.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run test and write coverage
         run: yarn test:coverage
       - name: "Run SonarCloud Scan"
-        if: ${{ success() }}
+        if: ${{ success() && github.actor != 'dependabot[bot]' }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Proposed changes

### What changed

Stops running sonar checks for dependabot PRs

### Why did it change

So that dependabot PR checks can succeed

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1530](https://govukverify.atlassian.net/browse/KIWI-1530)


[KIWI-1530]: https://govukverify.atlassian.net/browse/KIWI-1530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ