### PR TITLE
[IPS-476]: Add ECS step scaling policy and alarms

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -44,7 +44,7 @@ Parameters:
     Default: 3
   EnableScalingInDev:
     Type: Number
-    Default: 0
+    Default: 1
     Description: Set to 1 to enable deployment of scaling infra in dev
   IPVStubStackName:
     Type: String
@@ -732,6 +732,111 @@ Resources:
         TargetValue: 50.0
         ScaleInCooldown: 0
         ScaleOutCooldown: 0
+
+  StepScaleOutPolicy:
+    Condition: EnableScaling
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: StepScalingOutPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref BAVFrontEcsCluster
+          - !GetAtt BAVFrontEcsService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 120
+        MinAdjustmentMagnitude: 5
+        StepAdjustments:
+          - MetricIntervalLowerBound: 20
+            MetricIntervalUpperBound: 30
+            ScalingAdjustment: 200
+          - MetricIntervalLowerBound: 30
+            MetricIntervalUpperBound: 35
+            ScalingAdjustment: 300
+          - MetricIntervalLowerBound: 35
+            ScalingAdjustment: 500
+
+  StepScaleInPolicy:
+    Condition: EnableScaling
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: StepScalingInPolicy
+      PolicyType: StepScaling
+      ResourceId: !Join
+        - '/'
+        - - "service"
+          - !Ref BAVFrontEcsCluster
+          - !GetAtt BAVFrontEcsService.Name
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      StepScalingPolicyConfiguration:
+        AdjustmentType: PercentChangeInCapacity
+        Cooldown: 420
+        StepAdjustments:
+          - MetricIntervalUpperBound: -40
+            ScalingAdjustment: -50
+
+  StepScaleOutAlarm:
+    Condition: EnableScaling
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-StepScaleOutAlarm"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmActions:
+        - !Ref StepScaleOutPolicy
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmDescription: "BAVFrontEcsClusterOver60PercentCPU"
+      ComparisonOperator: "GreaterThanThreshold"
+      DatapointsToAlarm: "2"
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref BAVFrontEcsCluster
+        - Name: ServiceName
+          Value: !GetAtt BAVFrontEcsService.Name
+      Unit: "Percent"
+      EvaluationPeriods: "2"
+      MetricName: "CPUUtilization"
+      Namespace: "AWS/ECS"
+      Statistic: "Average"
+      Period: "60"
+      Threshold: "60"
+
+  StepScaleInAlarm:
+    Condition: EnableScaling
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-StepScaleInAlarm"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmActions:
+        - !Ref StepScaleInPolicy
+        - !ImportValue platform-alarm-topic-slack-warning-alert
+      AlarmDescription: "BAVFrontEcsClusterUnder60PercentCPU"
+      ComparisonOperator: "LessThanThreshold"
+      DatapointsToAlarm: "5"
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref BAVFrontEcsCluster
+        - Name: ServiceName
+          Value: !GetAtt BAVFrontEcsService.Name
+      Unit: "Percent"
+      EvaluationPeriods: "5"
+      MetricName: "CPUUtilization"
+      Namespace: "AWS/ECS"
+      Statistic: "Average"
+      Period: "60"
+      Threshold: "60"
 
   ### Front End API Gateway Custom Domain definition
 

--- a/template.yaml
+++ b/template.yaml
@@ -789,11 +789,8 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-StepScaleOutAlarm"
       ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-topic-slack-warning-alert
       AlarmActions:
         - !Ref StepScaleOutPolicy
-        - !ImportValue platform-alarm-topic-slack-warning-alert
       AlarmDescription: "BAVFrontEcsClusterOver60PercentCPU"
       ComparisonOperator: "GreaterThanThreshold"
       DatapointsToAlarm: "2"
@@ -817,11 +814,8 @@ Resources:
     Properties:
       AlarmName: !Sub "${AWS::StackName}-StepScaleInAlarm"
       ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-topic-slack-warning-alert
       AlarmActions:
         - !Ref StepScaleInPolicy
-        - !ImportValue platform-alarm-topic-slack-warning-alert
       AlarmDescription: "BAVFrontEcsClusterUnder60PercentCPU"
       ComparisonOperator: "LessThanThreshold"
       DatapointsToAlarm: "5"


### PR DESCRIPTION
## Proposed changes

Add ECS step scaling policy and alarms following https://govukverify.atlassian.net/wiki/spaces/Architecture/pages/3834744807/ADR+0140+Fargate+Scaling

### What changed

Created the following resources:
-  StepScaleOutPolicy
- StepScaleInPolicy
- StepScaleOutAlarm
- StepScaleInAlarm

### Why did it change

Align task scaling with CoreFront and orange/lime configurations

### Issue tracking

- [IPS-161](https://govukverify.atlassian.net/browse/IPS-161)
- [IPS-476](https://govukverify.atlassian.net/browse/IPS-476)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[IPS-161]: https://govukverify.atlassian.net/browse/IPS-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IPS-476]: https://govukverify.atlassian.net/browse/IPS-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ