### PR TITLE
KIWI-1549: Modify frontend URL on staging to run tests

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -128,7 +128,7 @@ Mappings:
       BACKENDSESSIONTABLE: "session-bav-cri-ddb"
       LOGLEVEL: "warn"
     staging:
-      EXTERNALWEBSITEHOST: "https://review-bav.staging.account.gov.uk"
+      EXTERNALWEBSITEHOST: "www.review-bav.staging.account.gov.uk/"
       APIBASEURL: "https://api.review-bav.staging.account.gov.uk"
       DNSSUFFIX: "review-bav.staging.account.gov.uk"
       SESSIONTABLENAME: "bav-front-sessions-staging"


### PR DESCRIPTION
## Proposed changes

Modify the BAV Front end URL on the staging environment to carry out the testing. 

### What changed

 FRONT_END_URL env var in the FE ECS `https://review-bav.staging.account.gov.uk/` to [www.review-bav.staging.account.gov.uk](http://www.review-bav.staging.account.gov.uk/)

### Why did it change
the custom domain we have setup for the FE apigw is [www.review-bav.staging.account.gov.uk](http://www.review-bav.staging.account.gov.uk/)

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->
