### PR TITLE
Formats sort code before submitting

### DIFF
--- a/src/app/bav/controllers/confirmDetails.js
+++ b/src/app/bav/controllers/confirmDetails.js
@@ -1,6 +1,6 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 const { API } = require("../../../lib/config");
-const { formatSortCode } = require("../utils");
+const { formatSortCode, formatSortCodeForSubmission } = require("../utils");
 
 class ConfirmDetailsController extends BaseController {
   locals(req, res, callback) {
@@ -26,7 +26,9 @@ class ConfirmDetailsController extends BaseController {
   async saveValues(req, res, callback) {
     try {
       const bavData = {
-        sort_code: req.sessionModel.get("sortCode"),
+        sort_code: formatSortCodeForSubmission(
+          req.sessionModel.get("sortCode")
+        ),
         account_number: req.sessionModel.get("accountNumber"),
       };
       await this.saveBavData(req.axios, bavData, req);

--- a/src/app/bav/steps.js
+++ b/src/app/bav/steps.js
@@ -65,6 +65,11 @@ module.exports = {
     skip: true,
     controller: abort,
   },
+  [`${APP.PATHS.DONE}`]: {
+    skip: true,
+    noPost: true,
+    next: APP.PATHS.OAUTH2,
+  },
   [`${APP.PATHS.ERROR}`]: {
     entryPoint: true,
   },

--- a/src/app/bav/utils.js
+++ b/src/app/bav/utils.js
@@ -8,4 +8,8 @@ function formatSortCode(sortCode) {
   return displaySortCode;
 }
 
-module.exports = { formatSortCode };
+function formatSortCodeForSubmission(sortCode) {
+  return sortCode.replace(/[ -]/g, "");
+}
+
+module.exports = { formatSortCode, formatSortCodeForSubmission };

--- a/src/app/bav/utils.test.js
+++ b/src/app/bav/utils.test.js
@@ -1,4 +1,4 @@
-const { formatSortCode } = require("./utils");
+const { formatSortCode, formatSortCodeForSubmission } = require("./utils");
 
 describe("formatSortCode", () => {
   it("returns a sort code without dashes in the format XX-XX-XX", () => {
@@ -7,5 +7,19 @@ describe("formatSortCode", () => {
 
   it("returns a sort code with spaces in the format XX-XX-XX", () => {
     expect(formatSortCode("12 34 56")).toBe("12-34-56");
+  });
+});
+
+describe("formatSortCodeForSubmission", () => {
+  it("removes spaces from sort code", () => {
+    expect(formatSortCodeForSubmission("12 34 56")).toBe("123456");
+  });
+
+  it("removes dashes from sort code", () => {
+    expect(formatSortCodeForSubmission("12-34-56")).toBe("123456");
+  });
+
+  it("returns sort code with no spaces or dashes", () => {
+    expect(formatSortCodeForSubmission("123456")).toBe("123456");
   });
 });

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -23,6 +23,7 @@ module.exports = {
       CANNOT_PROCEED: "/cannot-proceed",
       DONE: "/done",
       ERROR: "/error",
+      OAUTH2: "/oauth2/callback",
     },
     ANALYTICS: {
       DOMAIN: process.env.ANALYTICS_DOMAIN || "localhost",


### PR DESCRIPTION
## Proposed changes

### What changed

The backend requires a plain string with no dashes or spaces. This PR formats the sort code before it is submitted.

Also adds done route

### Why did it change

Fix validation error