### PR TITLE
Sets authorizationPath correctly

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -108,6 +108,7 @@ setAPIConfig({
   app,
   baseUrl: API.BASE_URL,
   sessionPath: API.PATHS.SESSION,
+  authorizationPath: API.PATHS.AUTHORIZATION,
 });
 
 setOAuthPaths({ app, entryPointPath: APP.PATHS.BAV });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Passes `authorizationPath` into the `setAPIConfig` function

### Why did it change

To fix this error
<img width="1240" alt="Screenshot 2024-01-19 at 11 34 08 am" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/40401118/d1b860e5-5d29-4d41-94fc-3ac04a805246">
