### PR TITLE
KIWI-1577: Rename retryCount to attemptCount and reset it on success

### DIFF
--- a/src/app/bav/controllers/confirmDetails.js
+++ b/src/app/bav/controllers/confirmDetails.js
@@ -42,12 +42,18 @@ class ConfirmDetailsController extends BaseController {
     const headers = {
       "x-govuk-signin-session-id": req.session.tokenId,
     };
+
     const res = await axios.post(`${API.PATHS.SAVE_BAVDATA}`, bavData, {
       headers,
     });
-    if (res.data.retryCount) {
-      req.sessionModel.set("retryCount", res.data.retryCount);
+
+    if (res.data.attemptCount) {
+      req.sessionModel.set("attemptCount", res.data.attemptCount);
+    } else {
+      // Reset the attemptCount if it in not included in the response
+      req.sessionModel.set("attemptCount", undefined);
     }
+
     return res.data;
   }
 }

--- a/src/app/bav/controllers/confirmDetails.test.js
+++ b/src/app/bav/controllers/confirmDetails.test.js
@@ -29,31 +29,30 @@ describe("ConfirmDetailsController", () => {
     expect(req.sessionModel.get("isLanding")).toEqual(false);
   });
 
-  it("should increment the retryCount sessionModel property when retryCount returned in API call", async () => {
+  it("should increment the attemptCount sessionModel property when attemptCount returned in API call", async () => {
     axios.post.mockResolvedValue({
       data: {
         message: "Success",
-        retryCount: 1,
+        attemptCount: 1,
       },
     });
 
     const bavData = {};
     await confirmDetailsController.saveBavData(axios, bavData, req);
 
-    expect(req.sessionModel.get("retryCount")).toEqual(1);
+    expect(req.sessionModel.get("attemptCount")).toEqual(1);
   });
 
-  it("should return undefined for retryCount sessionModel property when retryCount returned in API call as undefined", async () => {
+  it("should return undefined for attemptCount sessionModel property when attemptCount returned in API call as undefined", async () => {
     axios.post.mockResolvedValue({
       data: {
         message: "Success",
-        retryCount: undefined,
       },
     });
 
     const bavData = {};
     await confirmDetailsController.saveBavData(axios, bavData, req);
 
-    expect(req.sessionModel.get("retryCount")).toEqual(undefined);
+    expect(req.sessionModel.get("attemptCount")).toEqual(undefined);
   });
 });

--- a/src/app/bav/steps.js
+++ b/src/app/bav/steps.js
@@ -33,17 +33,22 @@ module.exports = {
   },
   [APP.PATHS.CONFIRM_DETAILS]: {
     controller: confirmDetails,
-    fields: ["retryCount"],
+    fields: ["attemptCount"],
     next: [
       {
-        field: "retryCount",
+        field: "attemptCount",
         value: undefined,
         next: APP.PATHS.DONE,
       },
       {
-        field: "retryCount",
+        field: "attemptCount",
         value: 1,
         next: APP.PATHS.COULD_NOT_MATCH,
+      },
+      {
+        field: "attemptCount",
+        value: 2,
+        next: APP.PATHS.DONE,
       },
     ],
   },

--- a/test/browser/features/UnHappyPath/BAVUnhappyAccountDetailsSecondFail.feature
+++ b/test/browser/features/UnHappyPath/BAVUnhappyAccountDetailsSecondFail.feature
@@ -1,0 +1,20 @@
+@success
+Feature: Provided Bank Details Failed
+
+   Background:
+        Given a user named Nigel has navigated to the BAV Landing Page
+        When the user clicks on Continue button
+        Then the user is directed to the Account Details screen
+
+    Scenario:  User failed on first attempt then failed on second attempt and is directed to IPV
+        Given the user has entered a Sort Code of "123456"
+        Given the user has entered an Account Number of "31926819"
+        When the user clicks the Continue button
+        When they click on the Continue to account details check button
+        When the user selects the 'Try Again' radio
+        When the user clicks the Continue button
+        Then the user is directed to the Confirm Details screen
+        When they click on the Continue to account details check button
+        Then the user is directed to IPV Core
+
+    


### PR DESCRIPTION
## Proposed changes

### What changed

Rename retryCount to attemptCount and reset it on success

### Why did it change

To allow push to success when user has 1 fail and 1 pass and 2 fails

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1577](https://govukverify.atlassian.net/browse/KIWI-1577)


[KIWI-1577]: https://govukverify.atlassian.net/browse/KIWI-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ