### PR TITLE
[KIWI -1577] QA - Route Users to IPV Core on Second Fail 

### DIFF
--- a/test/browser/features/UnHappyPath/BAVUnhappyAccountDetailsSecondFail.feature
+++ b/test/browser/features/UnHappyPath/BAVUnhappyAccountDetailsSecondFail.feature
@@ -1,0 +1,20 @@
+@success
+Feature: Provided Bank Details Failed
+
+   Background:
+        Given a user named Nigel has navigated to the BAV Landing Page
+        When the user clicks on Continue button
+        Then the user is directed to the Account Details screen
+
+    Scenario:  User selected 1st radio to return to Account Details Screen
+        Given the user has entered a Sort Code of "123456"
+        Given the user has entered an Account Number of "31926819"
+        When the user clicks the Continue button
+        When they click on the Continue to account details check button
+        When the user selects the 'Try Again' radio
+        When the user clicks the Continue button
+        Then the user is directed to the Confirm Details screen
+        When they click on the Continue to account details check button
+        Then the user is directed to IPV Core
+
+    

--- a/test/browser/features/UnHappyPath/BAVUnhappyAccountDetailsSecondFail.feature
+++ b/test/browser/features/UnHappyPath/BAVUnhappyAccountDetailsSecondFail.feature
@@ -6,7 +6,7 @@ Feature: Provided Bank Details Failed
         When the user clicks on Continue button
         Then the user is directed to the Account Details screen
 
-    Scenario:  User selected 1st radio to return to Account Details Screen
+    Scenario:  User failed on first attempt then failed on second attempt and is directed to IPV
         Given the user has entered a Sort Code of "123456"
         Given the user has entered an Account Number of "31926819"
         When the user clicks the Continue button


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Created tests for second fail attempt

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1577](https://govukverify.atlassian.net/browse/KIWI-1577)

## Checklists

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1577]: https://govukverify.atlassian.net/browse/KIWI-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ