### PR TITLE
[KIWI-1664]- BAV | FE | Incorrect tab title on all pages

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -4,7 +4,7 @@ buttons:
   continue: Parhau
 
 govuk:
-  serviceName:
+  serviceName: ""
   backLink: Yn ôl
   errorSummaryTitle: Mae problem
   error: Gwall

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -4,7 +4,7 @@ buttons:
   continue: Continue
 
 govuk:
-  serviceName:
+  serviceName: ""
   backLink: Back
   errorSummaryTitle: There is a problem
   error: Error


### PR DESCRIPTION
### What changed

Added empty quote in English and Welsh default yaml files to remove error showing govuk.serviceName in screen title tag

### Why did it change

Bug fix

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1664](https://govukverify.atlassian.net/browse/KIWI-1664)



[KIWI-1664]: https://govukverify.atlassian.net/browse/KIWI-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ