### PR TITLE
Updating template to return correct testHarness URL

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,7 +13,7 @@ export GITHUB_ACTIONS=true
 # shellcheck disable=SC2154
 export API_BASE_URL=$(remove_quotes "$CFN_BAVBackEndURL")
 export IPV_STUB_URL=$(remove_quotes $CFN_BAVIPVStubExecuteURL)start
-export TEST_HARNESS_URL=$(remove_quotes $CFN_BAVTestHarnessURL)
+export TEST_HARNESS_URL=$(remove_quotes $CFN_BAVTestHarnessURL)/
 export SESSION_TABLE=$(remove_quotes $CFN_BAVBackendSessionTableName)
 
 cd /app; yarn run test:e2e:cd

--- a/template.yaml
+++ b/template.yaml
@@ -113,7 +113,7 @@ Mappings:
       DNSSUFFIX: "review-bav.dev.account.gov.uk"
       SESSIONTABLENAME: "bav-front-sessions-dev"
       ANALYTICSDOMAIN: "dev.account.gov.uk"
-      TESTHARNESSURL: "https://testharness.review-bav.dev.account.gov.uk"
+      TESTHARNESSURL: "https://bav-test-harness-testharness.review-bav.dev.account.gov.uk"
       BACKENDURL: "https://api-bav-cri-api.review-bav.dev.account.gov.uk"
       BACKENDSESSIONTABLE: "session-bav-cri-ddb"
       LOGLEVEL: "debug"


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Update template.yml to return correct test harness url in cloud formation template

### Why did it change

E2E tests added to BAV FE repo require correct test harness URL for BE validation logic

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1672](https://govukverify.atlassian.net/browse/KIWI-1672)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1672]: https://govukverify.atlassian.net/browse/KIWI-1672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ