### PR TITLE
KIWI-1308: Add CSLS subscrptions for Splunk Onboarding

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -128,37 +128,37 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 504
+        "line_number": 503
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 506
+        "line_number": 505
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 507
+        "line_number": 506
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 510
+        "line_number": 509
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 512
+        "line_number": 511
       }
     ]
   },
-  "generated_at": "2024-02-23T10:14:36Z"
+  "generated_at": "2024-02-28T13:44:03Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -89,15 +89,15 @@ Mappings:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
   PlatformConfiguration:
     dev:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     build:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     staging:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     integration:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
     production:
-      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+      CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython-2
 
 # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
@@ -355,14 +355,13 @@ Resources:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-BAVFront-ECS
       RetentionInDays: 14
 
-  # CSLSECSAccessSubscriptionFilter:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   # Condition: IsNotDevelopment
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref ECSAccessLogsGroup
+  CSLSECSAccessSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Properties:
+      DestinationArn:
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref ECSAccessLogsGroup
 
   ECSFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter

--- a/template.yaml
+++ b/template.yaml
@@ -649,14 +649,14 @@ Resources:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-BAVFront-API-GW-AccessLogs
       RetentionInDays: 14
 
-  # CSLSAPIGWAccessSubscriptionFilter:
-  #   Type: AWS::Logs::SubscriptionFilter
-  #   Condition: IsNotDevelopment
-  #   Properties:
-  #     DestinationArn:
-  #       !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
-  #     FilterPattern: ""
-  #     LogGroupName: !Ref APIGWAccessLogsGroup
+  CSLSAPIGWAccessSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevelopment
+    Properties:
+      DestinationArn:
+        !FindInMap [PlatformConfiguration, !Ref Environment, CSLSEGRESS]
+      FilterPattern: ""
+      LogGroupName: !Ref APIGWAccessLogsGroup
 
   APIGWFatalErorMetricFilter:
     Type: AWS::Logs::MetricFilter


### PR DESCRIPTION
## Proposed changes
- Add CSLS subscription filter for the spunk onboarding. 
- Modified CSLS Egress stub 2

### What changed
- Enabled the CSLS filter subscription as splunk onboarding started
- BAV Accounts are added on the CSLS accounts which allows to push log groups
<!-- Describe the changes in detail - the "what"-->

### Why did it change
- For onboarding BAV CRI logs into splunk

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1308](https://govukverify.atlassian.net/browse/KIWI-1308)

## Checklists

### PII logging

- [ ] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[KIWI-1308]: https://govukverify.atlassian.net/browse/KIWI-1308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ