### PR TITLE
[KIWI-1607] -BAV | FE | Add warning to escape choice screen

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,9 +1,4 @@
 # title is managed in default.yml
 
-nameEntry:
-  title: "Rhowch eich enw yn union fel y mae'n ymddangos ar eich ID gyda llun"
-  surname: "Enw olaf"
-  givenNames: "Enw olaf"
-  firstName: "Enw cyntaf"
-  middleName: "Enwau canol"
-  middleNameHint: "Gadewch hwn yn wag os nad oes gennych enwau canol"
+howContinueBank: 
+  warning: Ni allwch ddychwelyd i'r sgrin hon os ydych yn chwilio am ffordd arall o brofi eich hunaniaeth.


### PR DESCRIPTION
### What changed

Translated warning label on escape choice screen as work for label had been done in previous ticket 

### Why did it change

So Welsh speakers can read the warning label

### Issue tracking

- [KIWI-1607](https://govukverify.atlassian.net/browse/KIWI-1607)

## Checklists

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1607]: https://govukverify.atlassian.net/browse/KIWI-1607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ