### PR TITLE
Remove Browser Tests

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -33,13 +33,13 @@ jobs:
       - run: yarn build
       - run: yarn prettier
       - run: yarn test
-      - name: Run browser tests
-        id: bavBrowserTests
-        run: yarn test:browser:ci
-        env: 
-            IPV_STUB_URL: ${{ secrets.IPV_STUB_URL }}
-            API_BASE_URL: ${{ secrets.API_BASE_URL }}
-            CUSTOM_FE_URL: http:/localhost:5040
+      # - name: Run browser tests
+      #   id: bavBrowserTests
+      #   run: yarn test:browser:ci
+      #   env: 
+      #       IPV_STUB_URL: ${{ secrets.IPV_STUB_URL }}
+      #       API_BASE_URL: ${{ secrets.API_BASE_URL }}
+      #       CUSTOM_FE_URL: http:/localhost:5040
       - name: Archive browser tests results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Proposed changes

Browser tests running pre-merge is causing intermittent unknown failures, whilst investigation for this is underway this PR temp removes browser testing from our pre-merge workflow