### PR TITLE
Use IPV Pretty Stub URL for IPV Core handoff testing

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,7 +12,7 @@ remove_quotes () {
 export GITHUB_ACTIONS=true
 # shellcheck disable=SC2154
 export API_BASE_URL=$(remove_quotes "$CFN_BAVBackEndURL")
-export IPV_STUB_URL=$(remove_quotes $CFN_BAVIPVStubPrettyApiURL)start
+export IPV_STUB_URL=$(remove_quotes $CFN_BAVIPVStubPrettyAPIURL)start
 export TEST_HARNESS_URL=$(remove_quotes $CFN_BAVTestHarnessURL)
 export SESSION_TABLE=$(remove_quotes $CFN_BAVBackendSessionTableName)
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,7 +12,7 @@ remove_quotes () {
 export GITHUB_ACTIONS=true
 # shellcheck disable=SC2154
 export API_BASE_URL=$(remove_quotes "$CFN_BAVBackEndURL")
-export IPV_STUB_URL=$(remove_quotes $CFN_BAVIPVStubExecuteURL)start
+export IPV_STUB_URL=$(remove_quotes $CFN_BAVIPVStubPrettyApiURL)start
 export TEST_HARNESS_URL=$(remove_quotes $CFN_BAVTestHarnessURL)
 export SESSION_TABLE=$(remove_quotes $CFN_BAVBackendSessionTableName)
 

--- a/template.yaml
+++ b/template.yaml
@@ -1343,7 +1343,7 @@ Outputs:
     Condition: IsNotProdLikeEnvironment
     Description: "BAV IPV Stub Pretty"
     Value:
-      Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubPrettyApiUrl'
+      Fn::ImportValue: !Sub '${IPVStubStackName}-IPvStubApiGatewayPrettyUrl'
   BAVTestHarnessURL:
     Condition: IsNotProdLikeEnvironment
     Description: "BAV Test Harness"

--- a/template.yaml
+++ b/template.yaml
@@ -1338,12 +1338,12 @@ Outputs:
     Condition: IsNotProdLikeEnvironment
     Description: "BAV IPV Stub"
     Value:
-      Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubPrettyApiUrl'
+      Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubExecuteUrl'
   BAVIPVStubPrettyAPIURL:
     Condition: IsNotProdLikeEnvironment
     Description: "BAV IPV Stub"
     Value:
-      Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubExecuteUrl'
+      Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubPrettyApiUrl'
   BAVTestHarnessURL:
     Condition: IsNotProdLikeEnvironment
     Description: "BAV Test Harness"

--- a/template.yaml
+++ b/template.yaml
@@ -1341,7 +1341,7 @@ Outputs:
       Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubExecuteUrl'
   BAVIPVStubPrettyAPIURL:
     Condition: IsNotProdLikeEnvironment
-    Description: "BAV IPV Stub"
+    Description: "BAV IPV Stub Pretty"
     Value:
       Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubPrettyApiUrl'
   BAVTestHarnessURL:

--- a/template.yaml
+++ b/template.yaml
@@ -1338,6 +1338,11 @@ Outputs:
     Condition: IsNotProdLikeEnvironment
     Description: "BAV IPV Stub"
     Value:
+      Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubPrettyApiUrl'
+  BAVIPVStubPrettyAPIURL:
+    Condition: IsNotProdLikeEnvironment
+    Description: "BAV IPV Stub"
+    Value:
       Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubExecuteUrl'
   BAVTestHarnessURL:
     Condition: IsNotProdLikeEnvironment


### PR DESCRIPTION
…sting

## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Update template.yml to output the pretty stub URL for use in testing 

### Why did it change

URL currently used for IPV_STUB_URL is https://vw5cq9hzu6.execute-api.eu-west-2.amazonaws.com/dev/ and we need this returned in pretty format for use in IPV Core handoff testing

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->
