### PR TITLE
[KIWI-1540] - BAV | FE | Welsh Translation copy changes

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -82,7 +82,7 @@ const { app, router } = setup({
     "views",
   ],
   translation: {
-    allowedLangs: ["en"],
+    allowedLangs: ["en", "cy"],
     fallbackLang: ["en"],
     cookie: { name: "lng" },
   },

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -1,27 +1,44 @@
-surname:
-  label: Enw olaf
-  hint: ""
+sortCode:
+  label: Cod didoli
+  hint: Mae eich cod didoli yn 6 digid o hyd. Mae'n 3 pâr o rifau. Er enghraifft, 802650.
+  prefix: ""
   validation:
-    default: "Rhowch eich enw olaf fel y mae'n ymddangos ar eich ID gyda llun"
-    maxlength: "Rhowch eich enw olaf fel y mae'n ymddangos ar eich ID gyda llun"
-    regexNumber: "Ni all eich enw olaf gynnwys rhifau"
-    regexSpecialCharacters: "Rhowch eich enw olaf fel y mae'n ymddangos ar eich ID gyda llun"
+    default: Rhowch eich cod didoli
+    regexNumber: Rhowch god didoli dilys. Er enghraifft, 802650
+
+accountNumber:
+  label: Rhif y cyfrif 
+  hint: Rhaid i rif eich cyfrif fod rhwng 6 ac 8 digid. Er enghraifft, 10014069.
+  prefix: ""
+  validation:
+    default: Rhowch rif eich cyfrif
+    minlength: Rhaid i rif eich cyfrif fod rhwng 6 ac 8 digid
+    maxlength: Rhaid i rif eich cyfrif fod rhwng 6 ac 8 digid
+
+howContinueBankChoice:
+  validation:
+    required: Dewiswch beth hoffech chi ei wneud
+  items:
+    proveAnotherWay: 
+      label: Stopio ddefnyddio'ch manylion banc a dod o hyd i ffordd arall o brofi eich hunaniaeth
+      hint: Ewch yn ôl i'r gwasanaeth rydych angen ei ddefnyddio neu ddefnyddiwch ID gyda llun.
+      reveal: ""
+    goBack: 
+      label: Parhau i ddefnyddio eich manylion banc i brofi eich hunaniaeth
+      hint: ""
+      reveal: ""
+      
+couldNotMatchChoice:
+  validation:
+    required: Dewiswch beth hoffech chi ei wneud
+  items:
+    tryAgain: 
+      label: Gwirio fanylion eich cyfrif banc neu gymdeithas adeiladu a cheisio eto
+      hint: ""
+      reveal: ""
+    proveAnotherWay: 
+      label: Dod o hyd i ffordd arall o brofi eich hunaniaeth
+      hint: Ni fyddwch yn gallu newid eich meddwl a defnyddio eich manylion banc.
+      reveal: ""
 
 
-firstName:
-  label: Enw cyntaf
-  hint: ""
-  validation:
-    default: "Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich ID gyda llun"
-    maxlength: "Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich ID gyda llun"
-    regexNumber: "Ni all eich enw cyntaf gynnwys rhifau"
-    regexSpecialCharacters: "Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich ID gyda llun"
-
-middleName:
-  label: Enw(au) canol
-  hint: Gadewch hwn yn wag os nad oes gennych unrhyw enwau canol
-  validation:
-    default: "Rhowch eich enw canol fel y mae'n ymddangos ar eich ID gyda llun"
-    maxlength: "Rhowch eich enw canol fel y mae'n ymddangos ar eich ID gyda llun"
-    regexNumber: "Ni all eich enw canol gynnwys rhifau"
-    regexSpecialCharacters: "Rhowch eich enw canol fel y mae'n ymddangos ar eich ID gyda llun"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,9 +1,49 @@
 # title is managed in default.yml
+            
+landingPage:
+  title: Parhau i roi manylion eich cyfrif banc neu gymdeithas adeiladu
+  infoText1: Nesaf, byddwn yn gofyn am rywfaint o wybodaeth am eich cyfrif.
+  list1: 
+    list1Text: "Rhaid iddo fod:"
+    list1Bullet1: yn gyfrif cyfredol neu gyfrif cyfredol ar y cyd
+    list1Bullet2: gyda banc neu gymdeithas adeiladu yn y DU
+    list1Bullet3: yn eich enw chi
+  list2: 
+    list2Text: "Ni allwch ddefnyddio:"
+    list2Bullet1: cyfrif busnes
+    list2Bullet2: cyfrif cynilo, gan gynnwys Cyfrif Cynilo Unigol (ISA)
+  infoTitle: Beth i'w ddisgwyl
+  list3: 
+    list3Text: "Bydd angen i chi ddweud wrthym y:"
+    list3Bullet1: cod didoli
+    list3Bullet2: rhif cyfrif
+  infoText3: Byddwn yn gwirio enw eich cyfrif a'ch manylion gyda'ch banc neu gymdeithas adeiladu.
+  infoText4: Rhaid i'ch enw a manylion cyfrif gyfateb.
+  detailDropdown:
+    summaryText: Sut rydym yn defnyddio eich manylion banc
+    detailContent: <p class="instruction">Ni fyddwn yn cadw nac yn rhannu manylion eich cyfrif.</p><p class="instruction">Nid ydym yn defnyddio manylion eich cyfrif i wirio neu gymryd unrhyw daliadau.</p>
+  howContinueBankLanding: 
+    howContinueBankLink: /how-continue-bank
+    howContinueBankText: "Rwyf angen profi fy hunaniaeth mewn ffordd arall"
 
-nameEntry:
-  title: "Rhowch eich enw yn union fel y mae'n ymddangos ar eich ID gyda llun"
-  surname: "Enw olaf"
-  givenNames: "Enw olaf"
-  firstName: "Enw cyntaf"
-  middleName: "Enwau canol"
-  middleNameHint: "Gadewch hwn yn wag os nad oes gennych enwau canol"
+howContinueBank: 
+  title: Beth hoffech chi ei wneud?
+  warning:
+  
+enterAccountDetails:
+  title: Rhowch fanylion eich cyfrif  
+
+checkDetails:
+  title: "Gwiriwch fod eich manylion yn cyfateb i'ch cyfrif banc neu gymdeithas adeiladu"
+  fullName: "Enw"
+  sortCode: "Cod didoli"
+  accountNumber: "Rhif y cyfrif"
+  changeLink: "Newid"
+  insetText: "Ni fyddwn yn defnyddio manylion eich cyfrif i wirio neu gymryd unrhyw daliadau."
+  submitDetails: "Cyflwyno manylion ar gyfer gwiriad banc"
+  noSubmitDetails: "Rwyf angen profi fy hunaniaeth mewn ffordd arall"
+
+couldNotMatch:
+  title: Nid oeddem yn gallu dod o hyd i wybodaeth sy'n cyfateb i'ch banc neu gymdeithas adeiladu
+  content: You can check your details and try again. You’ll only be able to do this once.
+  prompt: Beth hoffech chi ei wneud?

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -45,5 +45,5 @@ checkDetails:
 
 couldNotMatch:
   title: Nid oeddem yn gallu dod o hyd i wybodaeth sy'n cyfateb i'ch banc neu gymdeithas adeiladu
-  content: You can check your details and try again. You’ll only be able to do this once.
+  content: Gallwch wirio eich manylion a rhoi cynnig eto. Dim ond unwaith y gallwch wneud hyn.
   prompt: Beth hoffech chi ei wneud?

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -41,7 +41,7 @@ checkDetails:
   changeLink: "Change"
   insetText: "We will not use your account details to check or take any payments."
   submitDetails: "Submit details for bank check"
-  noSubmitDetails: "I do not want continue to bank details check"
+  noSubmitDetails: "I need to prove my identity another way"
 
 couldNotMatch:
   title: We could not match your details to your bank or building society


### PR DESCRIPTION
### What changed

Updated BAV journey to include Welsh translation for all text.

### Why did it change

So Welsh speaking users can access the BAV service.

### Issue tracking

- [KIWI-1540](https://govukverify.atlassian.net/browse/KIWI-1540)

<img width="361" alt="Screenshot 2024-03-13 at 17 10 16" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/117987734/db25bd2d-bc8c-477a-979a-eecfb17d05e8">


[KIWI-1540]: https://govukverify.atlassian.net/browse/KIWI-1540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ