### PR TITLE
PLAT-4023: Add DNS name pointing to Cloud Front on the build environment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         args: ["--baseline", ".secrets.baseline"]
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.4
+    rev: v1.5.5
     hooks:
       - id: remove-tabs
       - id: remove-crlf
@@ -25,7 +25,7 @@ repos:
       - id: search-and-replace
         stages: [commit-msg, commit]
   - repo: https://github.com/psf/black
-    rev: 24.1.1
+    rev: 24.3.0
     hooks:
       - id: black
         exclude: ^.*-hook/src/.*/models.py$
@@ -42,19 +42,19 @@ repos:
         name: isort (python)
         exclude: ^.*-hook/src/.*/models.py$
   - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.11.0
+    rev: v9.13.0
     hooks:
       - id: commitlint
         stages: [commit-msg]
         args: ['--verbose']
         verbose: true  # print warnings
   - repo: https://github.com/aws-cloudformation/cfn-python-lint
-    rev: v0.85.0
+    rev: v0.86.1
     hooks:
       - id: cfn-python-lint
         files: ^(?!\..*).*/template\.(json|yml|yaml)$
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: '3.2.3'
+    rev: '3.2.43'
     hooks:
       - id: checkov
         verbose: true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -75,10 +75,6 @@
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
-		{
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
-    },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
@@ -118,51 +114,51 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 81
+        "line_number": 83
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 91
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 531
+        "line_number": 533
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 533
+        "line_number": 535
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 534
+        "line_number": 536
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 537
+        "line_number": 539
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 539
+        "line_number": 541
       }
     ]
   },
-  "generated_at": "2024-03-04T22:23:13Z"
+  "generated_at": "2024-03-22T11:11:29Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -74,6 +74,8 @@ Conditions:
     - !Equals [!Ref Environment, production]
   IsNotProdLikeEnvironment: !Not
     - !Condition IsProdLikeEnvironment
+  IsBuildEnvironment: !Or
+    - !Equals [ !Ref Environment, build ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -426,7 +428,7 @@ Resources:
     Properties:
       ContainerDefinitions:
         - Essential: true
-          Image: CONTAINER-IMAGE-PLACEHOLDER        
+          Image: CONTAINER-IMAGE-PLACEHOLDER
           Name: app
           Environment:
             - Name: API_BASE_URL
@@ -892,8 +894,12 @@ Resources:
         - DNSSUFFIX: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
       Type: A
       HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}"
-      AliasTarget:
-        DNSName: !GetAtt BAVFrontCustomDomain.RegionalDomainName
+      AliasTarget: !If
+      - IsBuildEnvironment
+      - DNSName: d1rha1iw69aavp.cloudfront.net
+        HostedZoneId: E2TCW1GCFAO31P
+        EvaluateTargetHealth: false
+      - DNSName: !GetAtt BAVFrontCustomDomain.RegionalDomainName
         HostedZoneId: !GetAtt BAVFrontCustomDomain.RegionalHostedZoneId
         EvaluateTargetHealth: false
 

--- a/template.yaml
+++ b/template.yaml
@@ -897,7 +897,7 @@ Resources:
       AliasTarget: !If
       - IsBuildEnvironment
       - DNSName: d1rha1iw69aavp.cloudfront.net
-        HostedZoneId: E2TCW1GCFAO31P
+        HostedZoneId: Z2FDTNDATAQYW2
         EvaluateTargetHealth: false
       - DNSName: !GetAtt BAVFrontCustomDomain.RegionalDomainName
         HostedZoneId: !GetAtt BAVFrontCustomDomain.RegionalHostedZoneId


### PR DESCRIPTION
## Proposed changes
Test the Cloudfront pilot on the build environment. Test the DNS pointing to Cloudfront

### What changed
- Set the DNS name pointing to Cloudfront in the build environment
- Having tested the hostname pointing to Cloudfront manually, set up the DNS pointing to cloud front on the build environment only

### Why did it change

Test the cloud front pilot on the build environment

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [PLAT-4023](https://govukverify.atlassian.net/browse/PLAT-4023)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[PLAT-4023]: https://govukverify.atlassian.net/browse/PLAT-4023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ