### PR TITLE
BAU: Bump di-ipv-cri-common-express 6.2.0 to 6.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.515.0",
     "@aws-sdk/lib-dynamodb": "3.363.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "6.2.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "6.2.2",
     "@govuk-one-login/frontend-analytics": "1.0.3",
     "@govuk-one-login/frontend-passthrough-headers": "^0.0.1",
     "@govuk-one-login/one-login-language-toggle": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,10 +978,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz"
   integrity sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==
 
-"@govuk-one-login/di-ipv-cri-common-express@6.2.0":
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-6.2.0.tgz"
-  integrity sha512-SsuFDzZOtaPvT/p/ItrDkDTrkCoREmlL1GL5r0jA5bn2DLwkvJ4Jfhf7YW1kiEVBtTK2kMcvO5M5Hdix1euNqQ==
+"@govuk-one-login/di-ipv-cri-common-express@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-6.2.2.tgz#0c154ebf94588f37e60c63d2b087fda0ed5403b1"
+  integrity sha512-Yar63UjB7bVHid1bhxNP9DzkT5OmploNPOW9qxavmbj/n0pjEQoW1TjWCSpK7DBoxcjwgCru4rYHJbGK1LXF7w==
   dependencies:
     hmpo-logger "7.0.1"
     i18next "23.8.1"
@@ -7926,14 +7926,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -8586,7 +8579,7 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -8599,15 +8592,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Proposed changes

### What changed

Bumps common express from 6.2.0 to 6.2.2

### Why did it change

The recent GA4 package release had to be updated in common-express as well. Bumping this version will produce cleaner logs
