### PR TITLE
Updates tests to expect device_information in txma event

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,3 +13,5 @@ LOG_LEVEL="debug"
 # QA Environment Variables
 IPV_STUB_URL=
 CUSTOM_FE_URL=
+TEST_HARNESS_URL=
+SESSION_TABLE="session-bav-cri-ddb"

--- a/test/browser/support/BAV_COP_RESPONSE_RECEIVED_SCHEMA.json
+++ b/test/browser/support/BAV_COP_RESPONSE_RECEIVED_SCHEMA.json
@@ -59,6 +59,25 @@
       "required": [
         "evidence"
       ]
+    },
+    "restricted": {
+      "type": "object",
+      "properties": {
+        "device_information": {
+          "type": "object",
+          "properties": {
+            "encoded": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "encoded"
+          ]
+        }
+      },
+      "required": [
+        "device_information"
+      ]
     }
   },
   "required": [
@@ -67,7 +86,8 @@
     "timestamp",
     "event_timestamp_ms",
     "component_id",
-    "extensions"
+    "extensions",
+    "restricted"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Updates tests to expect device_information in txma event

### Why did it change

To allow testing of cloudfront work

### Screenshots

e2e tests passing against build env
<img width="1142" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/40401118/e57c235a-33e0-4040-8f93-5f68b98a494c">

