### PR TITLE
[KIWI-1798] - Remove the width limit on the error summary component

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -72,10 +72,6 @@ $govuk-assets-path: "/public/";
   margin-bottom: govuk-spacing(-6);
 }
 
-.govuk-error-summary {
-  width: 66.6666%;
-}
-
 .govuk-cookie-banner h2, .govuk-cookie-banner p {
   margin-top: 0; 
   margin-bottom: 20px;


### PR DESCRIPTION
### What changed

Changed width of error summary component

### Why did it change

To align with GOV UK design system

### Issue tracking

- [KIWI-1798](https://govukverify.atlassian.net/browse/KIWI-1798)


[KIWI-1798]: https://govukverify.atlassian.net/browse/KIWI-1798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ