### PR TITLE
Remove libappindicator1 from apt install

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,7 +12,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 RUN unzip awscliv2.zip
 RUN ./aws/install
 
-RUN apt install -y git jq openjdk-8-jdk fonts-liberation libappindicator1 procps libxkbcommon0 libgbm1
+RUN apt install -y git jq openjdk-8-jdk fonts-liberation procps libxkbcommon0 libgbm1
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Remove libappindicator1 from apt install

### Why did it change

It was causing an error and doesn't appear to be getting used

Before
<img width="1340" alt="Screenshot 2024-04-29 at 2 21 15 PM" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/40401118/265479f0-a3b6-438a-9aa5-9e7040f5d4ff">

After
<img width="1723" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/40401118/82bb1256-a1c2-422f-a268-a589bd3c8a91">
<img width="652" alt="image" src="https://github.com/govuk-one-login/ipv-cri-bav-front/assets/40401118/357a466e-f640-463f-b447-f874787a7589">
