### PR TITLE
IPS-715: Remove WAF Association from the frontend for cloudfront

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -685,12 +685,6 @@ Resources:
           "integrationLatency":"$context.integrationLatency"
           }
 
-  WAFv2ACLAssociation:
-    Type: AWS::WAFv2::WebACLAssociation
-    Properties:
-      ResourceArn: !Ref LoadBalancer
-      WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/Block/WafArn}}"
-
   APIGWAccessLogsGroup:
     Type: AWS::Logs::LogGroup
     Properties:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
- Remove the WAF association before deploy cloudfront WAF

### What changed
- Removed the WAF Association with the load balancer.
- This is to deploy the cloudfront and WAF global deployment

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- The WAF Association is removed to add the Global WAF to test Cloudfront
- Existing WAF will create a drift if association created on the global WAF

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-715](https://govukverify.atlassian.net/browse/IPS-715)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates


### Other considerations

<!-- Add any other consideration if needed -->


[IPS-715]: https://govukverify.atlassian.net/browse/IPS-715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

![Screenshot 2024-04-29 at 17 08 54](https://github.com/govuk-one-login/ipv-cri-bav-front/assets/131283983/be507f0b-eec9-41ac-936a-555ce20aec7e)
![Screenshot 2024-04-30 at 09 32 45](https://github.com/govuk-one-login/ipv-cri-bav-front/assets/131283983/fceb6759-8931-4e65-8273-8b42de23403d)
