### PR TITLE
IPS-689: Cloudfront DNS changeover on BAV build and staging environments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -114,51 +114,51 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 98
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 103
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 559
+        "line_number": 562
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 561
+        "line_number": 564
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 562
+        "line_number": 565
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 565
+        "line_number": 568
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 567
+        "line_number": 570
       }
     ]
   },
-  "generated_at": "2024-05-09T11:20:38Z"
+  "generated_at": "2024-05-10T13:32:58Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -57,7 +57,7 @@ Parameters:
   DeployAlarmsInDev:
     Description: "Set to the string value `true` to deploy alarms in a DEV environment"
     Type: String
-    Default: true
+    Default: false
 
 Conditions:
   IsNotDevelopment: !Or
@@ -86,8 +86,11 @@ Conditions:
     - Condition: IsNotDevelopment
     - !Equals [!Ref DeployAlarmsInDev, true]
   IsCloudFrontPilotTesting: !Or
-    - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, dev ]
+    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
+    - !Equals [ !Ref Environment, integration ]
+
 
 Mappings:
   EnvironmentConfiguration:

--- a/template.yaml
+++ b/template.yaml
@@ -86,7 +86,7 @@ Conditions:
     - Condition: IsNotDevelopment
     - !Equals [!Ref DeployAlarmsInDev, true]
   IsCloudFrontPilotTesting: !Or
-    - !Equals [ !Ref Environment, build ]
+    - !Equals [ !Ref Environment, staging ]
     - !Equals [ !Ref Environment, dev ]
 
 Mappings:
@@ -125,7 +125,7 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://bav-cri-front.review-bav.dev.account.gov.uk"
       APIBASEURL: "https://api-bav-cri-api.review-bav.dev.account.gov.uk"
       DNSSUFFIX: "review-bav.dev.account.gov.uk"
-      CLOUDFRONTDOMAIN: "d25esf8mgd14r2.cloudfront.net"
+      CLOUDFRONTDOMAIN: ""
       SESSIONTABLENAME: "bav-front-sessions-dev"
       GTMIDUA: "GTM-TK92W68"
       GTMIDGA4: "GTM-KD86CMZ"
@@ -141,7 +141,7 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://review-bav.build.account.gov.uk"
       APIBASEURL: "https://api.review-bav.build.account.gov.uk"
       DNSSUFFIX: "review-bav.build.account.gov.uk"
-      CLOUDFRONTDOMAIN: "d1f55zmmicygu2.cloudfront.net"
+      CLOUDFRONTDOMAIN: "d1mxjkhzwnn7rp.cloudfront.net"
       SESSIONTABLENAME: "bav-front-sessions-build"
       GTMIDUA: "GTM-TK92W68"
       GTMIDGA4: "GTM-KD86CMZ"
@@ -157,7 +157,7 @@ Mappings:
       EXTERNALWEBSITEHOST: "www.review-bav.staging.account.gov.uk/"
       APIBASEURL: "https://api.review-bav.staging.account.gov.uk"
       DNSSUFFIX: "review-bav.staging.account.gov.uk"
-      CLOUDFRONTDOMAIN: ""
+      CLOUDFRONTDOMAIN: "d3li6eih3gei2k.cloudfront.net"
       SESSIONTABLENAME: "bav-front-sessions-staging"
       GTMIDUA: "GTM-TK92W68"
       GTMIDGA4: "GTM-KD86CMZ"
@@ -170,7 +170,7 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://review-bav.integration.account.gov.uk"
       APIBASEURL: "https://api.review-bav.integration.account.gov.uk"
       DNSSUFFIX: "review-bav.integration.account.gov.uk"
-      CLOUDFRONTDOMAIN: ""
+      CLOUDFRONTDOMAIN: "d38g947wht95l2.cloudfront.net"
       SESSIONTABLENAME: "bav-front-sessions-integration"
       GTMIDUA: "GTM-TK92W68"
       GTMIDGA4: "GTM-KD86CMZ"

--- a/template.yaml
+++ b/template.yaml
@@ -125,7 +125,7 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://bav-cri-front.review-bav.dev.account.gov.uk"
       APIBASEURL: "https://api-bav-cri-api.review-bav.dev.account.gov.uk"
       DNSSUFFIX: "review-bav.dev.account.gov.uk"
-      CLOUDFRONTDOMAIN: ""
+      CLOUDFRONTDOMAIN: "d17j8dpxnaezxj.cloudfront.net"
       SESSIONTABLENAME: "bav-front-sessions-dev"
       GTMIDUA: "GTM-TK92W68"
       GTMIDGA4: "GTM-KD86CMZ"


### PR DESCRIPTION
- Due to latest changes from dev platform,  the dev environment could not be used as a test bed for the cloudfront.
- Deployed the latest stacks on the build, staging and integration
- Configured the build and staging envirnonent.
- Based on the test reports from the build and staging, cloudfront could be deployed on the integration and production

## Proposed changes
- Redeploy the cloudfront stacks due to the new changes on dev platform
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed
- Deployed on the dev environment and added the screenshot of test report
- Deployed the new changes on build, staging and integration
- Enabled the DNS switchover on dev, build, staging and integration

<!-- Describe the changes in detail - the "what"-->

### Why did it change
- Recent changes on the cloudfront distribution template.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-689](https://govukverify.atlassian.net/browse/IPS-689)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->
![Screenshot 2024-05-10 at 14 50 41](https://github.com/govuk-one-login/ipv-cri-bav-front/assets/131283983/4e0aa9c0-65a3-4ed3-a311-b035d48a2571)


[IPS-689]: https://govukverify.atlassian.net/browse/IPS-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ