### PR TITLE
IPS-733: Deploy the cloudfront stacks on the BAV CRI and DNS switchover

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -114,51 +114,51 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 98
+        "line_number": 92
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 100
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 562
+        "line_number": 556
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 564
+        "line_number": 558
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 565
+        "line_number": 559
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 568
+        "line_number": 562
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 570
+        "line_number": 564
       }
     ]
   },
-  "generated_at": "2024-05-10T13:32:58Z"
+  "generated_at": "2024-05-14T10:34:32Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -85,12 +85,6 @@ Conditions:
   DeployAlarms: !Or
     - Condition: IsNotDevelopment
     - !Equals [!Ref DeployAlarmsInDev, true]
-  IsCloudFrontPilotTesting: !Or
-    - !Equals [ !Ref Environment, dev ]
-    - !Equals [ !Ref Environment, build ]
-    - !Equals [ !Ref Environment, staging ]
-    - !Equals [ !Ref Environment, integration ]
-
 
 Mappings:
   EnvironmentConfiguration:
@@ -186,7 +180,7 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://review-bav.account.gov.uk"
       APIBASEURL: "https://api.review-bav.account.gov.uk"
       DNSSUFFIX: "review-bav.account.gov.uk"
-      CLOUDFRONTDOMAIN: ""
+      CLOUDFRONTDOMAIN: "d30vzur3x0l8yq.cloudfront.net"
       SESSIONTABLENAME: "bav-front-sessions-production"
       GTMIDUA: "GTM-TT5HDKV"
       GTMIDGA4: "GTM-K4PBJH3"
@@ -919,13 +913,9 @@ Resources:
         - DNSSUFFIX: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
       Type: A
       HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}"
-      AliasTarget: !If
-      - IsCloudFrontPilotTesting
-      - DNSName:  !FindInMap [EnvironmentVariables, !Ref Environment, CLOUDFRONTDOMAIN]
+      AliasTarget:
+        DNSName:  !FindInMap [EnvironmentVariables, !Ref Environment, CLOUDFRONTDOMAIN]
         HostedZoneId: Z2FDTNDATAQYW2
-        EvaluateTargetHealth: false
-      - DNSName: !GetAtt BAVFrontCustomDomain.RegionalDomainName
-        HostedZoneId: !GetAtt BAVFrontCustomDomain.RegionalHostedZoneId
         EvaluateTargetHealth: false
 
   BAVFrontApiOriginRecord:


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
- Deploy the cloudfront stacks for the BAV CRI and test switching the DNS.

### What changed
- Tested and verified the changes on staging environment 
- Cloudfront stacks are deployed on the BAV CRI Production
- DNS switchover is enabled on all environments
- Removed CloudFrontPilot Testing flags
<!-- Describe the changes in detail - the "what"-->

### Why did it change
- Implement cloudfront on BAV CRI
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-733](https://govukverify.atlassian.net/browse/IPS-733)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->
