### PR TITLE
KIWI-1852 Use correct ANALYTICS_COOKIE_DOMAIN

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -98,7 +98,7 @@ setI18n({
   router,
   config: {
     secure: true,
-    cookieDomain: APP.GTM.DOMAIN,
+    cookieDomain: APP.GTM.ANALYTICS_COOKIE_DOMAIN,
   },
 });
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Use correct var for ANALYTICS_COOKIE_DOMAIN

### Why did it change

Was breaking language cookie persistence

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1852](https://govukverify.atlassian.net/browse/KIWI-1852)


[KIWI-1852]: https://govukverify.atlassian.net/browse/KIWI-1852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ