### PR TITLE
KIWI-1863 - Abort Logic E2E Tests with DB Validation

### DIFF
--- a/test/browser/features/E2E/BAVEndToEnd.feature
+++ b/test/browser/features/E2E/BAVEndToEnd.feature
@@ -9,7 +9,31 @@ Feature: BAV Journey - E2E
         And the user has entered an Account Number of "00111111"
         When the user clicks the Continue button
         And they click on the Continue to account details check button
-        When the users session details are fetched the sessionTable
+        When the users session details are fetched the sessionTable using "authCode"
         And the userInfo endpoint is initiated
         Then the Verifiable Credential is stored as expected
-        And all TxMA events are recorded as expected
+        When I get 5 TxMA events from Test Harness
+        Then the "BAV_CRI_START" event matches the "BAV_CRI_START_SCHEMA" Schema
+        And the "BAV_COP_REQUEST_SENT" event matches the "BAV_COP_REQUEST_SENT_SCHEMA" Schema
+        And the "BAV_COP_RESPONSE_RECEIVED" event matches the "BAV_COP_RESPONSE_RECEIVED_SCHEMA" Schema
+        And the "BAV_CRI_VC_ISSUED" event matches the "BAV_CRI_VC_ISSUED_SCHEMA" Schema
+        And the "BAV_CRI_END" event matches the "BAV_CRI_END_SCHEMA" Schema
+
+    Scenario: BAV Journey - Abort Journey and DB Validation
+        Given a user has navigated to the BAV Landing Page
+        When the user clicks on Continue button
+        Then the user is directed to the Account Details screen
+        Given the user has entered a Sort Code of "12-34-56"
+        Given the user has entered an Account Number of "00111111"
+        When the user clicks the Continue button
+        Then the user is directed to the Check Your Answers screen
+        When the user clicks on 'I cannot provide UK account details' link
+        Then the user is directed to the Escape Choice screen
+        And the user wishes to exit the BAV process
+        And the user is directed to the Abort screen
+        When the user clicks the Continue button
+        And the users session details are fetched the sessionTable using "state"
+        When I get 2 TxMA events from Test Harness
+        Then the "BAV_CRI_START" event matches the "BAV_CRI_START_SCHEMA" Schema
+        And the "BAV_CRI_SESSION_ABORTED" event matches the "BAV_CRI_SESSION_ABORTED_SCHEMA" Schema
+

--- a/test/browser/pages/confirmDetailsPage.js
+++ b/test/browser/pages/confirmDetailsPage.js
@@ -35,6 +35,10 @@ module.exports = class PlaywrightDevPage {
     await this.page.locator("#submitDetails").click();
   }
 
+  async clickProveIdentityAnotherWay() {
+    await this.page.locator("#submitDetails").click();
+  }
+
   async getSavedSC() {
     const sort_code = this.page.locator("dd.govuk-summary-list__value").nth(1);
     let scValue = await sort_code.textContent();

--- a/test/browser/support/BAV_CRI_SESSION_ABORTED_SCHEMA.json
+++ b/test/browser/support/BAV_CRI_SESSION_ABORTED_SCHEMA.json
@@ -1,0 +1,68 @@
+{
+    "type": "object",
+    "properties": {
+        "event_name": {
+            "type": "string"
+        },
+        "user": {
+            "type": "object",
+            "properties": {
+                "user_id": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "govuk_signin_journey_id": {
+                    "type": "string"
+                },
+                "ip_address": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "user_id",
+                "session_id",
+                "govuk_signin_journey_id",
+                "ip_address"
+            ]
+        },
+        "timestamp": {
+            "type": "integer"
+        },
+        "event_timestamp_ms": {
+            "type": "integer"
+        },
+        "component_id": {
+            "type": "string"
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
+        }
+    },
+    "required": [
+        "event_name",
+        "user",
+        "timestamp",
+        "event_timestamp_ms",
+        "component_id",
+        "restricted"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
## E2E Test Results

![image](https://github.com/govuk-one-login/ipv-cri-bav-front/assets/110032361/de80c172-888f-4900-8d22-2769cd44d985)

## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Add E2E test to validate F2F Abort logic and validate to following:

- authSessionState = F2F_CRI_SESSION_ABORTED
- F2F_CRI_SESSION_ABORTED matched expected Schema

### Why did it change

Increase scope of E2E testing + support E2E testing of CloudFront changes.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1863](https://govukverify.atlassian.net/browse/KIWI-1863)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->
