### PR TITLE
[IPS-1003]-container task count alarm ecs service removed

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1233,7 +1233,6 @@ Resources:
 
   FELowContainerTaskCountAlarm:
     DependsOn:
-      - BAVFrontEcsService
       - BAVFrontEcsCluster
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
@@ -1260,14 +1259,11 @@ Resources:
               Dimensions:
                 - Name: ClusterName
                   Value: !Ref BAVFrontEcsCluster
-                - Name: ServiceName
-                  Value: !GetAtt BAVFrontEcsService.Name
             Period: 60
             Stat: Minimum
 
   FELowContainerTaskCountCriticalAlarm:
     DependsOn:
-      - BAVFrontEcsService
       - BAVFrontEcsCluster
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"
@@ -1294,8 +1290,6 @@ Resources:
               Dimensions:
                 - Name: ClusterName
                   Value: !Ref BAVFrontEcsCluster
-                - Name: ServiceName
-                  Value: !GetAtt BAVFrontEcsService.Name
             Period: 60
             Stat: Maximum
 


### PR DESCRIPTION
### What changed

BAVFrontEcsService dimension removed from FELowContainerTaskCountAlarm and FELowContainerTaskCountCriticalAlarm

### Why did it change

During canary deployment FELowContainerTaskCountCriticalAlarm critical alarm triggered as the alarm includes BAVFrontEcsService. When switching from ecs to code deploy, the target group is switched hence triggering the alarm

### Issue tracking

- [IPS-1003](https://govukverify.atlassian.net/browse/IPS-1003)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[IPS-1003]: https://govukverify.atlassian.net/browse/IPS-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ