### PR TITLE
IPS-1003 metric name updated to TaskCount

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1255,7 +1255,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: ECS/ContainerInsights
-              MetricName: RunningTaskCount
+              MetricName: TaskCount
               Dimensions:
                 - Name: ClusterName
                   Value: !Ref BAVFrontEcsCluster
@@ -1286,7 +1286,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: ECS/ContainerInsights
-              MetricName: RunningTaskCount
+              MetricName: TaskCount
               Dimensions:
                 - Name: ClusterName
                   Value: !Ref BAVFrontEcsCluster


### PR DESCRIPTION
### What changed

MetricName changed from running task count to task count for ContainerTaskCount alarms

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
FELowContainerTaskCountAlarm alarm still triggered. Further investigation shows that the metric name needs to be taskcount so it looks at all tasks in a cluster not just the running ones. 
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-metrics-ECS.html

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-1003](https://govukverify.atlassian.net/browse/IPS-1003)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->
