### PR TITLE
Update to  exclude the origin load balancer from the regional FMS policy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -132,37 +132,37 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 620
+        "line_number": 623
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 622
+        "line_number": 625
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 623
+        "line_number": 626
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 626
+        "line_number": 629
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 628
+        "line_number": 631
       }
     ]
   },
-  "generated_at": "2024-11-19T15:55:50Z"
+  "generated_at": "2025-02-03T08:52:05Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -327,6 +327,9 @@ Resources:
           - Key: routing.http.drop_invalid_header_fields.enabled
             Value: true
         - !Ref AWS::NoValue
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: false
 
   LoadBalancerListenerTargetGroupECS:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'


### PR DESCRIPTION
## Proposed changes

Added tags to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF

### What changed
Added tags

### Why did it change
to exclude the origin load balancer from FMS as it has it's own CloudFront specific WAF

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1407