### PR TITLE
[KIWI-2216] Upgrade FE analytics from v 2.0.1 to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@aws-sdk/credential-providers": "^3.577.0",
     "@aws-sdk/lib-dynamodb": "3.577.0",
     "@govuk-one-login/di-ipv-cri-common-express": "10.3.0",
-    "@govuk-one-login/frontend-analytics": "2.0.1",
+    "@govuk-one-login/frontend-analytics": "3.1.0",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",

--- a/src/views/bav/cannot-proceed.html
+++ b/src/views/bav/cannot-proceed.html
@@ -29,7 +29,7 @@
     {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next"),
     attributes: {
         "data-nav": true,
-        "data-link": "/abort"
+        "data-link": "/undefined"
       }}) }}
   
     {% endcall %}

--- a/src/views/bav/cannot-proceed.html
+++ b/src/views/bav/cannot-proceed.html
@@ -26,7 +26,11 @@
                 }
             }) }}
 
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next"),
+    attributes: {
+        "data-nav": true,
+        "data-link": "/abort"
+      }}) }}
   
     {% endcall %}
 

--- a/src/views/bav/check-details.html
+++ b/src/views/bav/check-details.html
@@ -74,7 +74,14 @@
 }) }}
 
 {% call hmpoForm(ctx) %}
-    {{ hmpoSubmit(ctx, {id: "submitDetails", attributes: {"data-testid": "confirm-details-continue-btn"}, text: translate("checkDetails.submitDetails")}) }}
+    {{ hmpoSubmit(ctx, {id: "submitDetails", 
+     text: translate("checkDetails.submitDetails"),
+     attributes: {
+      "data-testid": "confirm-details-continue-btn", 
+      "data-nav": true, 
+      "data-link": "/done"
+    }
+  }) }}
 
 {% endcall %}
 

--- a/src/views/bav/check-details.html
+++ b/src/views/bav/check-details.html
@@ -79,7 +79,7 @@
      attributes: {
       "data-testid": "confirm-details-continue-btn", 
       "data-nav": true, 
-      "data-link": "/done"
+      "data-link": "/undefined"
     }
   }) }}
 

--- a/src/views/bav/could-not-match-bank.html
+++ b/src/views/bav/could-not-match-bank.html
@@ -34,7 +34,12 @@
             }
         }) }}
 
-  {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+  {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next"),
+  attributes: {
+    "data-nav": true,
+    "data-link": "/abort"
+    }
+}) }}
   
   {% endcall %}
   <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>

--- a/src/views/bav/could-not-match-bank.html
+++ b/src/views/bav/could-not-match-bank.html
@@ -37,7 +37,7 @@
   {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next"),
   attributes: {
     "data-nav": true,
-    "data-link": "/abort"
+    "data-link": "/undefined"
     }
 }) }}
   

--- a/src/views/bav/enter-account-details.html
+++ b/src/views/bav/enter-account-details.html
@@ -28,7 +28,12 @@
       classes: "govuk-input--width-10 govuk-input--extra-letter-spacing"
     })}}
 
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next"),
+     attributes: {
+        "data-nav": true,
+        "data-link": "/check-details"
+    }
+    }) }}
 
     {% endcall %}
 </div>

--- a/src/views/bav/how-continue-bank.html
+++ b/src/views/bav/how-continue-bank.html
@@ -32,7 +32,12 @@
         classes: "govuk-!-padding-bottom-5"
       }) }}
 
-    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next"),
+    attributes: {
+      "data-nav": true,
+      "data-link": "/abort"
+    }
+  }) }}
 
   {% endcall %}
   <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>

--- a/src/views/bav/how-continue-bank.html
+++ b/src/views/bav/how-continue-bank.html
@@ -35,7 +35,7 @@
     {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next"),
     attributes: {
       "data-nav": true,
-      "data-link": "/abort"
+      "data-link": "/undefined"
     }
   }) }}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1009,12 +1009,13 @@
     nocache "^3.0.4"
     redis "^4.7.0"
 
-"@govuk-one-login/frontend-analytics@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-2.0.1.tgz#ff843241de1d1475407f719fb3f0f7180fc62dc1"
-  integrity sha512-8xAsQrRomVYxedFOQ8JDVdYx1JReJevSjU5EDZlcS/x3PhpCxm9DHjEqyOIvTo34zkFFoI4f2um6YkdD9IRQAg==
+"@govuk-one-login/frontend-analytics@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-3.1.0.tgz#7b8ad99ede1f5a0dbf81a62f375f26036d8b1e02"
+  integrity sha512-cHjuTWo7fLRwxjIcJCDG8cLheH/te77TZ03gDPvwvMRxI3xmCZ0HDQ2fVAHn6PMzOzPxODn5EUQIUQKxWhJskw==
   dependencies:
     copy-webpack-plugin "^12.0.2"
+    loglevel "^1.9.1"
 
 "@govuk-one-login/frontend-language-toggle@^1.1.0":
   version "1.1.0"
@@ -1027,6 +1028,13 @@
   integrity sha512-Tg8bh40F9cQHi13WpuwskI5wT0kgdgnl9l6I6kxKmlIWxL07tVbfS3MxDGVTXUttQfhnJvKKEem2hJr8LLA/dw==
   dependencies:
     forwarded-parse "^2.1.2"
+    pino "^8.20.0"
+
+"@govuk-one-login/frontend-vital-signs@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-vital-signs/-/frontend-vital-signs-0.1.3.tgz#31225add2eb135b5176094ec2e5165b08c8e5413"
+  integrity sha512-cRzEsicoIGq/l6T07gRXWEeUb9RKY0eq4sa6/2IpZwBlUSDFdwbMMY3IO7BZ+WrOcOlrjuOb0KYfSAO7vu8wGA==
+  dependencies:
     pino "^8.20.0"
 
 "@hapi/hoek@^9.0.0", "@hapi/hoek@^9.3.0":
@@ -6719,6 +6727,11 @@ lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+loglevel@^1.9.1:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
+  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
+
 lolex@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
@@ -8701,7 +8714,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -8771,7 +8793,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@6.0.1, strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9445,7 +9474,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -9458,6 +9487,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
### What changed

Upgraded frontend-analytics package version and added missing data attributes used for GA4 navigation tracking

### Why did it change

To ensure service is up to date and capturing analytics data correctly

### Issue tracking

- [KIWI-2216](https://govukverify.atlassian.net/browse/KIWI-2216)

## Evidence

![image](https://github.com/user-attachments/assets/f344514c-6cd7-420c-a1d5-370d603f3e43)


[KIWI-2216]: https://govukverify.atlassian.net/browse/KIWI-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ