### PR TITLE
[KIWI-2015] - | CM | Ensure that there is a 5XX Alarm if more than 80% of your traffic is returning 5XX in 2 of 5 datapoints.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1180,6 +1180,7 @@ Resources:
 
   FE5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevelopment
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
       AlarmDescription: >

--- a/template.yaml
+++ b/template.yaml
@@ -1180,7 +1180,7 @@ Resources:
 
   FE5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: IsNotDevelopment
+    Condition: "DeployAlarms"
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
       AlarmDescription: >
@@ -1188,10 +1188,10 @@ Resources:
         and a minimum of 2 errors in 5 out of the last 5 minutes
       ActionsEnabled: true
       OKActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
+        # - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       AlarmActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
+        # - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       EvaluationPeriods: 5
       DatapointsToAlarm: 2

--- a/template.yaml
+++ b/template.yaml
@@ -1136,11 +1136,9 @@ Resources:
       AlarmDescription: !Sub "Trigger the alarm if errorThreshold exceeds 10% with a minimum of 150 invocations and a minimum of 5 errors in 5 out of the last 5 minutes ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
-        - !ImportValue platform-alarm-topic-critical-alert
+        - !ImportValue platform-alarm-topic-slack-warning-alert
       AlarmActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
-        - !ImportValue platform-alarm-topic-critical-alert
+        - !ImportValue platform-alarm-topic-slack-warning-alert
       InsufficientDataActions: []
       Dimensions: []
       EvaluationPeriods: 5
@@ -1189,10 +1187,8 @@ Resources:
         and a minimum of 2 errors in 5 out of the last 5 minutes
       ActionsEnabled: true
       OKActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       AlarmActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
@@ -1223,7 +1219,7 @@ Resources:
               MetricName: 5xx
               Dimensions:
                 - Name: ApiId
-                  Value: !GetAtt ApiGwHttpEndpoint
+                  Value: !Ref ApiGwHttpEndpoint
             Period: 60
             Stat: Sum
         - Id: errorPercentage

--- a/template.yaml
+++ b/template.yaml
@@ -1180,6 +1180,57 @@ Resources:
           ReturnData: false
           Expression: (error/invocations) * 100
 
+  FE5XXErrorCriticalAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
+      AlarmDescription: >
+        Trigger the 5XX cricical alarm if errorThreshold exceeds 80% with 10 or more invocations
+        and a minimum of 2 errors in 5 out of the last 5 minutes
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
+        - !ImportValue platform-alarm-topic-critical-alert
+      AlarmActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
+        - !ImportValue platform-alarm-topic-critical-alert
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 80
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations<10,0,errorPercentage)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: error
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5xx
+              Dimensions:
+                - Name: ApiId
+                  Value: !GetAtt ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error/invocations)*100
+
   FE4XXErrorAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: "DeployAlarms"

--- a/template.yaml
+++ b/template.yaml
@@ -1188,8 +1188,10 @@ Resources:
         and a minimum of 2 errors in 5 out of the last 5 minutes
       ActionsEnabled: true
       OKActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       AlarmActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       EvaluationPeriods: 5
       DatapointsToAlarm: 2

--- a/template.yaml
+++ b/template.yaml
@@ -1180,7 +1180,7 @@ Resources:
 
   FE5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: IsNotDevelopment
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
       AlarmDescription: >
@@ -1188,10 +1188,10 @@ Resources:
         and a minimum of 2 errors in 5 out of the last 5 minutes
       ActionsEnabled: true
       OKActions:
-        # - !ImportValue platform-alarm-pagerduty-alert-topic
+        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       AlarmActions:
-        # - !ImportValue platform-alarm-pagerduty-alert-topic
+        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       EvaluationPeriods: 5
       DatapointsToAlarm: 2

--- a/template.yaml
+++ b/template.yaml
@@ -1139,6 +1139,7 @@ Resources:
         - !ImportValue platform-alarm-topic-slack-warning-alert
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
+      # Invocation count to be reviewed
       InsufficientDataActions: []
       Dimensions: []
       EvaluationPeriods: 5


### PR DESCRIPTION
### What changed

Implement 5XX critical alarm with Slack notifications to send alerts when there is a high volume of 5XX errors

### Why did it change

To alert team Kiwi so that they can respond to the errors

### Issue tracking

- [KIWI-2015](https://govukverify.atlassian.net/browse/KIWI-2015)

<!-- Add any other consideration if needed -->


[KIWI-2015]: https://govukverify.atlassian.net/browse/KIWI-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ