### PR TITLE
KIWI-2012 - Adding Package name to hmpo-logger

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -30,6 +30,7 @@ const {
 } = require("@govuk-one-login/frontend-vital-signs");
 
 const {
+  PACKAGE_NAME,
   API,
   APP,
   PORT,
@@ -182,7 +183,7 @@ router.use(wizard(steps, fields, wizardOptions));
 
 router.use((err, req, res, next) => {
   logger
-    .get()
+    .get(PACKAGE_NAME)
     .error(
       "Error caught by Express handler - redirecting to Callback with server_error",
       { err },

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 
 module.exports = {
+  PACKAGE_NAME: "di-ipv-cri-bav-front",
   API: {
     BASE_URL:
       process.env.API_BASE_URL ||


### PR DESCRIPTION
### What changed
Added name to hmpo-logger.get() function to prevent use of sync API which blocks event loop

