### PR TITLE
KIWI-2262 - Bump common-express version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.577.0",
     "@aws-sdk/lib-dynamodb": "3.577.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "10.7.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "10.7.1",
     "@govuk-one-login/frontend-analytics": "3.1.0",
     "@govuk-one-login/frontend-device-intelligence": "^1.1.0",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,10 +988,10 @@
     "@eslint/core" "^0.10.0"
     levn "^0.4.1"
 
-"@govuk-one-login/di-ipv-cri-common-express@10.7.0":
-  version "10.7.0"
-  resolved "https://registry.yarnpkg.com/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-10.7.0.tgz#e6b79ba90611f18dc400ffbe9e56b44c46683767"
-  integrity sha512-BjkXKhI0+z2/Vww1t90j1n6xasHzXq4dwHswrq3ltLOU1g27PnVZe8ladgQ0cXWUKlwL3F0vY8ClC+0SGU+HnA==
+"@govuk-one-login/di-ipv-cri-common-express@10.7.1":
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-10.7.1.tgz#f6e6a894f4861b20ce6c3af81554d0319ba6ef5d"
+  integrity sha512-vFtecSTm/k81qQBmOJmf3xgZLvANf228IT8ThRF8rJHBZ5aC8MA/bxcojooy0ggYDUgOP23VD2AaXLwSRoO3Pw==
   dependencies:
     async "^3.2.6"
     compression "^1.7.5"


### PR DESCRIPTION
### What changed

Updated common-express package to latest version which includes fix for device intelligence feature toggle.

### Issue tracking

- [KIWI-2262](https://govukverify.atlassian.net/browse/KIWI-2262)

[KIWI-2262]: https://govukverify.atlassian.net/browse/KIWI-2262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ