### PR TITLE
KIWI-2323 - DI | Turn off Device Intelligence in Staging

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -181,7 +181,7 @@ Mappings:
       minECSCount: 2
       maxECSCount: 4
       LANGUAGETOGGLEDISABLED: false
-      DEVICEINTELLIGENCEENABLED: true
+      DEVICEINTELLIGENCEENABLED: false
     integration:
       EXTERNALWEBSITEHOST: "https://review-bav.integration.account.gov.uk"
       APIBASEURL: "https://api.review-bav.integration.account.gov.uk"


### PR DESCRIPTION
### What changed

Disabled Device Intelligence in Staging env by setting the value of `DEVICEINTELLIGENCEENABLED` env var in CF template to `false`

### Why did it change

To unblock IPV core pipelines as referenced [here]([here](https://gds.slack.com/archives/C05HE9FL65S/p1747759982973109?thread_ts=1747756522.823159&cid=C05HE9FL65S))

### Issue tracking

- [KIWI-2323](https://govukverify.atlassian.net/browse/KIWI-2323)


[KIWI-2323]: https://govukverify.atlassian.net/browse/KIWI-2323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ