### PR TITLE
[KIWI-2318] - DI | Set Cookie domain for all environments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -143,37 +147,37 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 707
+        "line_number": 714
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 709
+        "line_number": 716
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 710
+        "line_number": 717
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 713
+        "line_number": 720
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 715
+        "line_number": 722
       }
     ]
   },
-  "generated_at": "2025-04-14T13:09:56Z"
+  "generated_at": "2025-05-22T11:09:56Z"
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -48,7 +48,8 @@ module.exports = {
     LANGUAGE_TOGGLE_DISABLED: process.env.LANGUAGE_TOGGLE_DISABLED || true,
     DEVICE_INTELLIGENCE_ENABLED:
       process.env.DEVICE_INTELLIGENCE_ENABLED || false,
-    DEVICE_INTELLIGENCE_DOMAIN: process.env.DEVICE_INTELLIGENCE_DOMAIN || "localhost",
+    DEVICE_INTELLIGENCE_DOMAIN:
+      process.env.DEVICE_INTELLIGENCE_DOMAIN || "localhost",
   },
   PORT: process.env.PORT || 5040,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -48,7 +48,7 @@ module.exports = {
     LANGUAGE_TOGGLE_DISABLED: process.env.LANGUAGE_TOGGLE_DISABLED || true,
     DEVICE_INTELLIGENCE_ENABLED:
       process.env.DEVICE_INTELLIGENCE_ENABLED || false,
-    DEVICE_INTELLIGENCE_DOMAIN: process.env.FRONTEND_DOMAIN || "localhost",
+    DEVICE_INTELLIGENCE_DOMAIN: process.env.DEVICE_INTELLIGENCE_DOMAIN || "localhost",
   },
   PORT: process.env.PORT || 5040,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/template.yaml
+++ b/template.yaml
@@ -148,6 +148,7 @@ Mappings:
       LOGLEVEL: "debug"
       LANGUAGETOGGLEDISABLED: false
       GA4ENABLED: true
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       minECSCount: 1
       maxECSCount: 4
       DEVICEINTELLIGENCEENABLED: true
@@ -164,6 +165,7 @@ Mappings:
       BACKENDSESSIONTABLE: "session-bav-cri-ddb"
       LOGLEVEL: "warn"
       GA4ENABLED: true
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       minECSCount: 6
       maxECSCount: 60
       LANGUAGETOGGLEDISABLED: false
@@ -178,6 +180,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       LOGLEVEL: "warn"
       GA4ENABLED: true
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       minECSCount: 2
       maxECSCount: 4
       LANGUAGETOGGLEDISABLED: false
@@ -192,6 +195,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       LOGLEVEL: "warn"
       GA4ENABLED: true
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       minECSCount: 2
       maxECSCount: 4
       LANGUAGETOGGLEDISABLED: false
@@ -206,6 +210,7 @@ Mappings:
       GTMIDGA4: "GTM-K4PBJH3"
       LOGLEVEL: "warn"
       GA4ENABLED: true
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       minECSCount: 6
       maxECSCount: 60
       LANGUAGETOGGLEDISABLED: false
@@ -610,6 +615,8 @@ Resources:
                 - IsProduction
                 - "account.gov.uk"
                 - !Sub "${Environment}.account.gov.uk"
+            - Name: DEVICE_INTELLIGENCE_DOMAIN
+              Value: !FindInMap [ EnvironmentVariables, !Ref Environment, DEVICEINTELLIGENCEDOMAIN ]
             - Name: LANGUAGE_TOGGLE_DISABLED
               Value: !FindInMap [EnvironmentVariables, !Ref Environment, LANGUAGETOGGLEDISABLED ]
             - Name: LOG_LEVEL


### PR DESCRIPTION
### What changed

Set device intelligence cookie domain to account.gov.uk across all envs

### Why did it change

To address issue with header size stemming from environment specific domain names

### Issue tracking

- [KIWI-2318](https://govukverify.atlassian.net/browse/KIWI-2318)

![Screenshot 2025-05-22 at 12 36 09](https://github.com/user-attachments/assets/9b26ae99-6814-4557-a338-0b7db5be43cd)



[KIWI-2318]: https://govukverify.atlassian.net/browse/KIWI-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ