### PR TITLE
[KIWI-2251] - | FE | Enable feature flag for Device Intelligence in INT and PROD

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -169,7 +169,7 @@ Mappings:
       minECSCount: 6
       maxECSCount: 60
       LANGUAGETOGGLEDISABLED: false
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
     staging:
       EXTERNALWEBSITEHOST: "www.review-bav.staging.account.gov.uk/"
       APIBASEURL: "https://api.review-bav.staging.account.gov.uk"
@@ -184,7 +184,7 @@ Mappings:
       minECSCount: 2
       maxECSCount: 4
       LANGUAGETOGGLEDISABLED: false
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
     integration:
       EXTERNALWEBSITEHOST: "https://review-bav.integration.account.gov.uk"
       APIBASEURL: "https://api.review-bav.integration.account.gov.uk"
@@ -199,7 +199,7 @@ Mappings:
       minECSCount: 2
       maxECSCount: 4
       LANGUAGETOGGLEDISABLED: false
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
     production:
       EXTERNALWEBSITEHOST: "https://review-bav.account.gov.uk"
       APIBASEURL: "https://api.review-bav.account.gov.uk"
@@ -214,7 +214,7 @@ Mappings:
       minECSCount: 6
       maxECSCount: 60
       LANGUAGETOGGLEDISABLED: false
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
 
 Resources:
   # Security Groups for the ECS service and load balancer


### PR DESCRIPTION
### What changed

Turned on Device Intelligence in build, staging, integration and production

### Why did it change

To enable the program to collect collection and analysis of data from end user devices and satisfy HMRC Day2 Must Have requirements

### Issue tracking

- [KIWI-2251](https://govukverify.atlassian.net/browse/KIWI-2251)

[KIWI-2251]: https://govukverify.atlassian.net/browse/KIWI-2251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ