### PR TITLE
[KIWI-2348B] - Update references in template file

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -394,7 +394,7 @@ Resources:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ECSCluster"
         - Key: Product
-          Value: "GOV.UK sign in"
+          Value: "GOV.UK One login"
         - Key: System
           Value: "BAV"
         - Key: Environment
@@ -453,7 +453,7 @@ Resources:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ECS"
         - Key: Product
-          Value: "GOV.UK sign in"
+          Value: "GOV.UK One login"
         - Key: System
           Value: "BAV"
         - Key: Environment
@@ -670,7 +670,7 @@ Resources:
         - Key: Name
           Value: !Sub "${AWS::StackName}-TaskDefinition"
         - Key: Product
-          Value: "GOV.UK sign in"
+          Value: "GOV.UK One login"
         - Key: System
           Value: "BAV"
         - Key: Environment


### PR DESCRIPTION
## Proposed changes

### What changed

Replaced references of "GOV.UK Sign In" with "GOV.UK One login" in template file

### Why did it change

Remove inconsistencies descriptions for BAV FE

### Issue tracking

- [KIWI-2348](https://govukverify.atlassian.net/browse/KIWI-2348)
- [KIWI-2195](https://govukverify.atlassian.net/browse/KIWI-2195)


[KIWI-2348]: https://govukverify.atlassian.net/browse/KIWI-2348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KIWI-2195]: https://govukverify.atlassian.net/browse/KIWI-2195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ