### PR TITLE
[KIWI-2331] - BAV | FE | Enable the Rebrand feature flag in Integration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -203,7 +203,7 @@ Mappings:
       maxECSCount: 4
       LANGUAGETOGGLEDISABLED: false
       DEVICEINTELLIGENCEENABLED: true
-      MAY2025REBRANDENABLED: false
+      MAY2025REBRANDENABLED: true
     production:
       EXTERNALWEBSITEHOST: "https://review-bav.account.gov.uk"
       APIBASEURL: "https://api.review-bav.account.gov.uk"


### PR DESCRIPTION
## Proposed changes

### What changed
Set the Rebrand feature flag in Integration to true

### Why did it change

To align with rebranding and allow for further E2E testing.

### Issue tracking

- [KIWI-2331](https://govukverify.atlassian.net/browse/KIWI-2331)


[KIWI-2331]: https://govukverify.atlassian.net/browse/KIWI-2331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ