### PR TITLE
[KIWI 2409] - BAV | FE | Computed font size of footer smaller than minimum 16px

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "express": "4.21.2",
     "express-async-errors": "3.1.1",
     "express-session": "^1.18.1",
-    "govuk-frontend": "4.10.0",
+    "govuk-frontend": "4.10.1",
     "hmpo-app": "3.0.1",
     "hmpo-components": "^7.1.0",
     "hmpo-config": "4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4796,10 +4796,10 @@ got@<12:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
-govuk-frontend@4.10.0:
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.10.0.tgz#520b30e1778ee05de4bdf52866b9cfa4574b9d71"
-  integrity sha512-oHwHdpycGZ7H6Skual1teBWN+0b+PYirifJkX8tQz1m7UWZb4JapppuOaVzcLD+11Q1hqqUJgR3gXDCosO9d4w==
+govuk-frontend@4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.10.1.tgz#a67a680f34339c210d59ed0f6c473af29c975744"
+  integrity sha512-k7wKjPpLovQlfOiBt0A3RHQCpNagOR8xpfMgvTEQkX6Id5njYNzQTsBvpArDKAxI2174csv2uzn02py02zTVLA==
 
 graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
   version "4.2.11"


### PR DESCRIPTION
## Proposed changes
### What changed

Upgraded `frontend-ui` to 1.3.9 and upgraded `govuk-frontend` to 4.10.1

### Why did it change

To fix issue of computed font size of text in the footer is smaller than the 16px minimum, and fix incorrect peer dependency

### Issue tracking

- [KIWI-2409](https://govukverify.atlassian.net/browse/KIWI-2409)

### Font size in the footer has been increased
### Before
<img width="1305" height="259" alt="Screenshot 2025-07-21 at 12 57 51" src="https://github.com/user-attachments/assets/65858b5c-3808-4fe1-a36b-c601fd2932d9" />

### After
<img width="1308" height="267" alt="Screenshot 2025-07-21 at 12 58 19" src="https://github.com/user-attachments/assets/24ea10d0-0c35-48ab-9f23-53bfa8197133" />


[KIWI-2409]: https://govukverify.atlassian.net/browse/KIWI-2409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ