### PR TITLE
[KIWI-2423] - Dependabot | Sprint 6 | Update yaml file 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     - dependabot
     ignore:
       - dependency-name: "node"
-        versions: ["14.x","15.x","16.x","17.x","18.x","20.x"]
+        versions: ["14.x","15.x","16.x","17.x","18.x","20.x","24.x"]
     groups:
       awssdk:
         patterns:
@@ -25,6 +25,9 @@ updates:
     target-branch: main
     labels:
     - dependabot
+    ignore:
+      - dependency-name: "node"
+        versions: ["24.x"]
     commit-message:
       prefix: BAU
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Proposed changes

### What changed

Updated dependabot yaml to ignored node 24 in docker file

### Why did it change

To ignore node 24 in docker
### Issue tracking

- [KIWI-2423](https://govukverify.atlassian.net/browse/KIWI-2423)



[KIWI-2423]: https://govukverify.atlassian.net/browse/KIWI-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ