### PR TITLE
[KIWI-2609] - Axios upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ajv": "8.18.0",
     "ajv-formats": "2.1.1",
     "aws4-axios": "3.4.0",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "connect-dynamodb": "3.0.5",
     "dotenv": "16.3.1",
     "express": "4.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2564,14 +2564,14 @@ axe-playwright@2.1.0:
     junit-report-builder "^5.1.1"
     picocolors "^1.1.1"
 
-axios@1.13.5:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
-  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
+axios@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
+    proxy-from-env "^2.1.0"
 
 axios@^1.13.2:
   version "1.14.0"
@@ -5696,11 +5696,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 proxy-from-env@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
## Proposed changes

### What changed

Bumped Axios from 1.13.5 -> 1.15.0

### Why did it change

To address critical vulnerabilities

### Issue tracking

- [KIWI-2609](https://govukverify.atlassian.net/browse/KIWI-2609)


[KIWI-2609]: https://govukverify.atlassian.net/browse/KIWI-2609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ