### PR TITLE
fix:IPS-2290 tune ECS auto-scaling policies for dual-CPU Fargate inst…

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -220,7 +220,7 @@ Mappings:
       LOGLEVEL: "warn"
       GA4ENABLED: true
       DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
-      minECSCount: 3
+      minECSCount: 6
       maxECSCount: 60
       LANGUAGETOGGLEDISABLED: false
       DEVICEINTELLIGENCEENABLED: true
@@ -998,7 +998,7 @@ Resources:
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 120
-        MinAdjustmentMagnitude: 1
+        MinAdjustmentMagnitude: 3
         StepAdjustments:
           - MetricIntervalLowerBound: 10
             MetricIntervalUpperBound: 15

--- a/template.yaml
+++ b/template.yaml
@@ -165,7 +165,7 @@ Mappings:
       LOGLEVEL: "warn"
       GA4ENABLED: true
       DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
-      minECSCount: 6
+      minECSCount: 3
       maxECSCount: 60
       LANGUAGETOGGLEDISABLED: false
       DEVICEINTELLIGENCEENABLED: true
@@ -220,7 +220,7 @@ Mappings:
       LOGLEVEL: "warn"
       GA4ENABLED: true
       DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
-      minECSCount: 6
+      minECSCount: 3
       maxECSCount: 60
       LANGUAGETOGGLEDISABLED: false
       DEVICEINTELLIGENCEENABLED: true
@@ -998,12 +998,12 @@ Resources:
       StepScalingPolicyConfiguration:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 120
-        MinAdjustmentMagnitude: 5
+        MinAdjustmentMagnitude: 1
         StepAdjustments:
-          - MetricIntervalLowerBound: 20
-            MetricIntervalUpperBound: 30
+          - MetricIntervalLowerBound: 10
+            MetricIntervalUpperBound: 15
             ScalingAdjustment: 200
-          - MetricIntervalLowerBound: 30
+          - MetricIntervalLowerBound: 15
             MetricIntervalUpperBound: 35
             ScalingAdjustment: 300
           - MetricIntervalLowerBound: 35
@@ -1027,7 +1027,7 @@ Resources:
         AdjustmentType: PercentChangeInCapacity
         Cooldown: 420
         StepAdjustments:
-          - MetricIntervalUpperBound: -40
+          - MetricIntervalUpperBound: -20
             ScalingAdjustment: -50
 
   StepScaleOutAlarm:
@@ -1041,7 +1041,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref StepScaleOutPolicy
-      AlarmDescription: "BAVFrontEcsClusterOver60PercentCPU"
+      AlarmDescription: "BAVFrontEcsClusterOver30PercentCPU"
       ComparisonOperator: "GreaterThanThreshold"
       DatapointsToAlarm: "2"
       Dimensions:
@@ -1055,7 +1055,7 @@ Resources:
       Namespace: "AWS/ECS"
       Statistic: "Average"
       Period: "60"
-      Threshold: "60"
+      Threshold: "30"
 
   StepScaleInAlarm:
     Condition: EnableScaling
@@ -1066,7 +1066,7 @@ Resources:
       ActionsEnabled: true
       AlarmActions:
         - !Ref StepScaleInPolicy
-      AlarmDescription: "BAVFrontEcsClusterUnder60PercentCPU"
+      AlarmDescription: "BAVFrontEcsClusterUnder30PercentCPU"
       ComparisonOperator: "LessThanThreshold"
       DatapointsToAlarm: "5"
       Dimensions:
@@ -1080,7 +1080,7 @@ Resources:
       Namespace: "AWS/ECS"
       Statistic: "Average"
       Period: "60"
-      Threshold: "60"
+      Threshold: "30"
 
   ### Front End API Gateway Custom Domain definition
 


### PR DESCRIPTION
Node.js is single-threaded so max CPU utilisation on a 2-vCPU task reports ~50%. Previous thresholds (60%) were unreachable, effectively disabling scaling.

## Proposed changes

### What changed

Changes:
- Reduce scale-out alarm threshold from 60% to 30%
- Reduce predictive scaling target from 60% to 30%
- Lower min instance count from 6 to 3 in build (3 AZs)
- Set MinAdjustmentMagnitude to 3
- Re-tune step adjustments to align with achievable CPU metrics
- Add scale-in steps to return to baseline after traffic subsides

Now the scaling alarms are triggered at 30% CPU utilisation. 

StepAdjustments are also adjusted for when to scale:

- **3** extra instances when CPU is utilised at **30%** (30 + 0) instead of 80% (60+20)
- **6** extra instances when CPU is utilised at **40%** (30 + 10) and 
- **15** extra instances when CPU is utilised at **45%** (30 +15)

and for scale in policies:

- Remove **10%** of instances when CPU drops below **20%** (30 - 10)
- Remove **50%** of instances when CPU drops below **10%** (30 - 20)

MinAdjustmentMagnitude of 3 which is the proposed minimum number of ECS instances will mean during a scaling event at least 3 new instances get created. 

### Why did it change

Currently the scaling policies are **ineffective**. They never work and that's because we have a dual CPU fargate instance running node application which is single thread. This means when the application reaches its full capacity we are only at 50% CPU capacity. Current scaling policies scale at 60% therefore we need to bring those values to under 50%.

### Issue tracking

- [IPS-2290](https://govukverify.atlassian.net/browse/IPS-2290)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [x] No environment variables or secrets were added or changed


### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[IPS-2290]: https://govukverify.atlassian.net/browse/IPS-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ