### PR TITLE
feat(DFC-1226): Remove content ID from error page

### DIFF
--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -7,7 +7,7 @@
 {% set isPageDataSensitive = false %}
 {% set statusCode = '200' %}
 {% set pageTitleKey = "error.unrecoverable.title" %}
-{% set contentID = "ddfca8ac-8a6e-4692-a418-b357b67823fe" %}
+
 {% set taxLevel2 = 'bav' %}
 {% set isPageDynamic = false %}
 {% set loggedInStatus = true %}


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

Removes GA content ID for the error page. This is so content ID will be determined by the page that had the error, rather than the error page itself.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DFC-1226](https://govukverify.atlassian.net/browse/DFC-1226)

[DFC-1226]: https://govukverify.atlassian.net/browse/DFC-1226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ